### PR TITLE
create-bot: Add multistage docker build

### DIFF
--- a/packages/create-bot/template/Dockerfile.hbs
+++ b/packages/create-bot/template/Dockerfile.hbs
@@ -1,6 +1,6 @@
 {{emit_if features.docker}}
-FROM node:20-alpine
-WORKDIR /app
+FROM node:22-alpine AS build
+WORKDIR /build
 
 RUN apk add python3 make g++ && \
     corepack enable && \
@@ -9,7 +9,14 @@ RUN apk add python3 make g++ && \
 COPY package*.json pnpm*.yaml {{#if features.typescript}}tsconfig.json{{/if}} ./
 RUN pnpm install --frozen-lockfile
 
-COPY src /app/src
+COPY src ./src
 RUN pnpm run build
+RUN pnpm prune --prod
 
-CMD [ "node", "/app/dist/main.js" ]
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=build /build/package*.json ./
+COPY --from=build /build/dist ./dist
+COPY --from=build /build/node_modules ./node_modules
+
+ENTRYPOINT [ "docker-entrypoint.sh", "node", "/app/dist/main.js" ]


### PR DESCRIPTION
Add multistage docker build to reduce resulting image size.
This also bumps `node:20-alpine` to `node:22-alpine` and uses `ENTRYPOINT` instead of `CMD` to directly pass command line arguments to the bot.

Image size comparison:
```
# multistage
mtproto_exporter                    0.0.1-b10    9d273b352321   32 seconds ago       186MB

# no multistage
mtproto_exporter                    0.0.1-b3     abd8a55e65ff   13 hours ago         586MB
```