### PR TITLE
fix(core): download chunk request need add offset

### DIFF
--- a/packages/core/src/highlevel/methods/files/download-iterable.ts
+++ b/packages/core/src/highlevel/methods/files/download-iterable.ts
@@ -156,7 +156,7 @@ export async function* downloadAsIterable(
                     _: isWeb ? 'upload.getWebFile' : 'upload.getFile',
                     // eslint-disable-next-line
                     location: location as any,
-                    offset: chunkSize * chunk,
+                    offset: offset + chunkSize * chunk,
                     limit: chunkSize,
                 },
                 {


### PR DESCRIPTION
I use downloadAsIterable method to resume download from a breakpoint, but the media cannot be opened when it is downloaded by sending an offset parameter.


My code is like that:

```js

const filePath = `${savePath}/${fileName}`;
const tempFilePath = `${tempPath}/${fileName}`;

let offset = 0;

if (fs.existsSync(tempFilePath)) {
	const stats = fs.statSync(tempFilePath);
	offset = Math.floor(stats.size / 4096) * 4096;
	console.log(`Found existing temp file with size: ${stats.size} bytes, adjusted offset to: ${offset} bytes`);
}

const stream = botClient.downloadAsNodeStream(media, {
	  partSize,
	  /**
	   * Offset in bytes. Must be divisible by 4096 (4 KB).
	   */
	  offset,
}

const writeStream = fs.createWriteStream(tempFilePath, {
	  flags: offset === 0 ? 'w' : 'a',
});

stream.pipe(writeStream);
```

When the temp file exists, the media cannot be opened correctly after the media download is finished. But it works correctly if the temp file does not exist.

The problem is that the offset was not added as a parameter when downloading the file chunk. When the offset was added, it worked. The media can be opened correctly.