### PR TITLE
Fix ignored reconnectionStrategy param

### DIFF
--- a/packages/core/src/network/persistent-connection.ts
+++ b/packages/core/src/network/persistent-connection.ts
@@ -69,6 +69,7 @@ export abstract class PersistentConnection {
                 this.log.debug('connecting to %j', dc)
                 return params.transport.connect(dc)
             },
+            strategy: params.reconnectionStrategy,
             onOpen: this._onOpen.bind(this),
             onClose: this._onClose.bind(this),
             onError: this._onError.bind(this),


### PR DESCRIPTION
The `reconnectionStrategy` param is currently ignored because it is not passed to Fuman's [PersistentConnection](https://github.com/teidesu/fuman/blob/31eb4b0cb45c09fe6bf3e8f34f23b519c9cddb95/packages/net/src/reconnection.ts#L68) constructor.