### PR TITLE
chore(create-bot): add envalid support for cleaner .env handling

### DIFF
--- a/packages/create-bot/src/dependencies.ts
+++ b/packages/create-bot/src/dependencies.ts
@@ -43,6 +43,10 @@ export function buildDependenciesList(config: UserConfig): DependenciesList {
         }
     }
 
+    if (config.features.includes(MtcuteFeature.Envalid)) {
+        dependencies.push('dotenv', 'envalid')
+    }
+
     if (config.features.includes(MtcuteFeature.Linters)) {
         devDependencies.push('@antfu/eslint-config')
     }

--- a/packages/create-bot/src/features/cli.ts
+++ b/packages/create-bot/src/features/cli.ts
@@ -38,6 +38,12 @@ export function getFeatureChoices(packageMananger: PackageManager): CheckboxChoi
             value: MtcuteFeature.Linters,
             checked: true,
         })
+        arr.unshift({
+            name: ' 🧼 Use Envalid',
+            short: 'Envalid',
+            value: MtcuteFeature.Envalid,
+            checked: true,
+        })
     }
 
     if (packageMananger === PackageManager.Pnpm) {

--- a/packages/create-bot/src/features/types.ts
+++ b/packages/create-bot/src/features/types.ts
@@ -3,6 +3,7 @@ export enum MtcuteFeature {
     Dispatcher = 'dispatcher',
     Docker = 'docker',
     TypeScript = 'typescript',
+    Envalid = 'envalid',
     Linters = 'linters',
     Git = 'git',
 }

--- a/packages/create-bot/template/src/env.js.hbs
+++ b/packages/create-bot/template/src/env.js.hbs
@@ -9,7 +9,16 @@ const BOT_TOKEN = Deno.env.get('BOT_TOKEN')
 {{/if}}
 {{else}}
 import process from 'node:process'
+{{#if features.envalid}}
+import 'dotenv/config'
+import { cleanEnv, num, str } from 'envalid'
 
+const env = cleanEnv(process.env, {
+    API_ID: num(),
+    API_HASH: str(),
+    BOT_TOKEN: str({ default: undefined }),
+})
+{{else}}
 const API_ID = Number.parseInt(process.env.API_ID)
 const API_HASH = process.env.API_HASH
 {{#if botToken}}
@@ -17,8 +26,15 @@ const BOT_TOKEN = process.env.BOT_TOKEN
 {{/if}}
 {{/if}}
 
+{{#unless features.envalid}}
 if (Number.isNaN(API_ID) || !API_HASH) {
     throw new Error('API_ID or API_HASH not set!')
 }
+{{/unless}}
 
+{{#if features.envalid}}
+export default env
+{{else}}
 export { API_HASH, API_ID{{#if botToken}}, BOT_TOKEN{{/if}} }
+{{/if}}
+{{/if}}

--- a/packages/create-bot/template/src/env.ts.hbs
+++ b/packages/create-bot/template/src/env.ts.hbs
@@ -9,7 +9,16 @@ const BOT_TOKEN = Deno.env.get('BOT_TOKEN')!
 {{/if}}
 {{else}}
 import process from 'node:process'
+{{#if features.envalid}}
+import 'dotenv/config'
+import { cleanEnv, num, str } from 'envalid'
 
+const env = cleanEnv(process.env, {
+    API_ID: num(),
+    API_HASH: str(),
+    BOT_TOKEN: str({ default: undefined }),
+})
+{{else}}
 const API_ID = Number.parseInt(process.env.API_ID!)
 const API_HASH = process.env.API_HASH!
 {{#if botToken}}
@@ -17,8 +26,15 @@ const BOT_TOKEN = process.env.BOT_TOKEN!
 {{/if}}
 {{/if}}
 
+{{#unless features.envalid}}
 if (Number.isNaN(API_ID) || !API_HASH) {
     throw new Error('API_ID or API_HASH not set!')
 }
+{{/unless}}
 
+{{#if features.envalid}}
+export default env
+{{else}}
 export { API_HASH, API_ID{{#if botToken}}, BOT_TOKEN{{/if}} }
+{{/if}}
+{{/if}}

--- a/packages/create-bot/template/src/main.js.hbs
+++ b/packages/create-bot/template/src/main.js.hbs
@@ -10,7 +10,11 @@ import { TelegramClient } from '@mtcute/deno'
 import { TelegramClient } from '@mtcute/node'
 {{/if}}
 
+{{#if features.envalid}}
+import env from './env.js'
+{{else}}
 import * as env from './env.js'
+{{/if}}
 {{#if features.i18n}}
 import { tr } from './i18n/index.js'
 {{/if}}

--- a/packages/create-bot/template/src/main.ts.hbs
+++ b/packages/create-bot/template/src/main.ts.hbs
@@ -10,10 +10,18 @@ import { TelegramClient } from '@mtcute/deno'
 import { TelegramClient } from '@mtcute/node'
 {{/if}}
 
+{{#if features.envalid}}
+{{#if (eq runtime "node")}}
+import env from './env.js'
+{{else if (eq runtime "bun")}}
+import env from './env.ts'
+{{/if}}
+{{else}}
 {{#if (eq runtime "node")}}
 import * as env from './env.js'
 {{else}}
 import * as env from './env.ts'
+{{/if}}
 {{/if}}
 {{#if features.i18n}}
 {{#if (eq runtime "node")}}


### PR DESCRIPTION
https://github.com/af/envalid for cleaner .env handling

this pull request will added a new option (default to `true`) for whether to use Envalid or not

```console
? Select features: (Press <space> to select, <a> to toggle all, <i> to invert selection, and <enter> to proceed)
 ◉  🧼 Use Envalid
 ◉  🥰 Setup ESLint with @antfu/eslint-config
 ◯  🌐 Internationalization
 ◉  📨 Event dispatcher
❯◉  ✨ Use TypeScript
 ◉  📦 Initialize git repository
 ◉  🐳 Generate Dockerfile
```

the reason i chose the soap emoji (🧼) is because i previously used the gear emoji (⚙️), but the spacing was not work,
and soap represents "cleaning," which fits the purpose of Envalid

Preview of generated typescript code:

src/env.ts
```ts
import process from 'node:process'

import { cleanEnv, num, str } from 'envalid'
import 'dotenv/config'

const env = cleanEnv(process.env, {
    API_ID: num(),
    API_HASH: str(),
    BOT_TOKEN: str({ default: undefined }),
})

export default env
```

and after that, you can just import it anywhere on your project
```ts
import env from './env.js'
```

this is my first pull request, so i apologize if there is any mistakes, also please feel free to give any feedback or suggestions

