### PR TITLE
fix(core): clamp negative setTimeout in ServerSaltManager

### DIFF
--- a/packages/core/src/network/server-salt.ts
+++ b/packages/core/src/network/server-salt.ts
@@ -32,10 +32,11 @@ export class ServerSaltManager {
   private _timer?: timers.Timer
 
   private _scheduleReplace(salt: mtp.RawMt_future_salt): void {
+    const delay = Math.max(0, salt.validSince * 1000 - Date.now())
     this._timer = timers.setTimeout(() => {
       this.currentSalt = salt.salt
       this._replaceAndScheduleNext()
-    }, salt.validSince * 1000 - Date.now())
+    }, delay)
   }
 
   private _replaceAndScheduleNext(): void {


### PR DESCRIPTION
## Summary

- Clamp `_scheduleReplace` delay to `Math.max(0, ...)` so already-valid salts fire immediately instead of scheduling a negative timer

When a stored session has future salts whose `validSince` is in the past (but `validUntil` is still in the future), `_scheduleReplace` computes `salt.validSince * 1000 - Date.now()` which goes negative. Node.js clamps to 1ms and emits a `TimeoutNegativeWarning` on every connect.

Fixes #132