### PR TITLE
fix(core): handle multi-record responses in fake-tls codec

### DIFF
--- a/packages/core/src/network/mtproxy/_fake-tls.test.ts
+++ b/packages/core/src/network/mtproxy/_fake-tls.test.ts
@@ -1,0 +1,128 @@
+import type { ISyncWritable } from '@fuman/io'
+import type { IPacketCodec } from '../transports/index.js'
+import { Bytes, write } from '@fuman/io'
+import { u8 } from '@fuman/utils'
+import { defaultTestCryptoProvider } from '@mtcute/test'
+import { describe, expect, it } from 'vitest'
+
+import { FakeTlsPacketCodec } from './_fake-tls.js'
+
+// A stand-in for ObfuscatedPacketCodec(IntermediatePacketCodec): an AES-CTR
+// stream cipher (stateful across the whole connection, like the real obfuscation
+// layer) over a uint32le length-prefixed framer. AES-CTR is non-rewindable, so
+// this reproduces the corruption the buggy decode caused by rewinding a record
+// it had already fed to the inner codec — a stateless inner would not surface it.
+async function makeStatefulInner(): Promise<IPacketCodec> {
+  const crypto = await defaultTestCryptoProvider()
+  const key = new Uint8Array(32).fill(0x2B)
+  const iv = new Uint8Array(16).fill(0x17)
+  const enc = crypto.createAesCtr(key, iv, true)
+  const dec = crypto.createAesCtr(key, iv, false)
+  let acc = new Uint8Array(0)
+
+  return {
+    setup() {},
+    tag: async () => new Uint8Array(0),
+    reset() {},
+    async encode(packet: Uint8Array, into: ISyncWritable): Promise<void> {
+      const framed = new Uint8Array(4 + packet.length)
+      new DataView(framed.buffer).setUint32(0, packet.length, true)
+      framed.set(packet, 4)
+      write.bytes(into, enc.process(framed))
+    },
+    async decode(reader: Bytes): Promise<Uint8Array | null> {
+      if (reader.available > 0) {
+        acc = u8.concat2(acc, dec.process(reader.readSync(reader.available)))
+      }
+      if (acc.length < 4) return null
+      const length = new DataView(acc.buffer, acc.byteOffset, acc.byteLength).getUint32(0, true)
+      if (acc.length - 4 < length) return null
+      const out = acc.slice(4, 4 + length)
+      acc = acc.slice(4 + length)
+      return out
+    },
+  } as unknown as IPacketCodec
+}
+
+async function encodeToWire(...packets: Uint8Array[]): Promise<Uint8Array> {
+  const codec = new FakeTlsPacketCodec(await makeStatefulInner())
+  // Set `_tag` to empty so encode does not prepend the obfuscation handshake tag
+  // (in the real flow that is exchanged out of band, never inside a framed payload).
+  await codec.tag()
+  const into = Bytes.alloc(packets.reduce((n, p) => n + p.length, 0) + 256)
+  for (const p of packets) await codec.encode(p, into)
+  return into.result().slice()
+}
+
+// Mirrors @fuman/io FramedReader.read: append a chunk, drain frames via
+// decode()+reclaim() until decode returns null, then read the next chunk.
+async function decodeFrames(chunks: Uint8Array[]): Promise<Uint8Array[]> {
+  const codec = new FakeTlsPacketCodec(await makeStatefulInner())
+  const buffer = Bytes.alloc(64)
+  const frames: Uint8Array[] = []
+  for (const chunk of chunks) {
+    write.bytes(buffer, chunk)
+    for (;;) {
+      const frame = await codec.decode(buffer, false)
+      buffer.reclaim()
+      if (frame === null) break
+      frames.push(frame)
+    }
+  }
+  return frames
+}
+
+function pattern(size: number, seed = 0): Uint8Array {
+  const b = new Uint8Array(size)
+  for (let i = 0; i < size; i++) b[i] = (i * 31 + seed) % 251
+  return b
+}
+
+function splitInto(wire: Uint8Array, chunk: number): Uint8Array[] {
+  const out: Uint8Array[] = []
+  for (let i = 0; i < wire.length; i += chunk) out.push(wire.subarray(i, Math.min(i + chunk, wire.length)))
+  return out
+}
+
+describe('FakeTlsPacketCodec', () => {
+  it('round-trips a small response that fits in one TLS record', async () => {
+    const packet = pattern(120)
+    const frames = await decodeFrames([await encodeToWire(packet)])
+    expect(frames).toHaveLength(1)
+    expect(frames[0]).toEqual(packet)
+  })
+
+  it('round-trips a large response spanning multiple coalesced TLS records', async () => {
+    // 8000 > MAX_TLS_PACKET_LENGTH (2878) → encode slices it into several records.
+    const packet = pattern(8000)
+    const wire = await encodeToWire(packet)
+    expect(wire.length).toBeGreaterThan(2878 * 2)
+    const frames = await decodeFrames([wire]) // all records arrive coalesced
+    expect(frames).toHaveLength(1)
+    expect(frames[0]).toEqual(packet)
+  })
+
+  it('round-trips a multi-record response split across reads (records cut mid-stream)', async () => {
+    const packet = pattern(20000, 5)
+    // 777 is coprime with the record stride, so reads land mid-header and mid-payload.
+    const frames = await decodeFrames(splitInto(await encodeToWire(packet), 777))
+    expect(frames).toHaveLength(1)
+    expect(frames[0]).toEqual(packet)
+  })
+
+  it('reassembles a multi-record frame delivered byte by byte', async () => {
+    const packet = pattern(6000, 9)
+    const frames = await decodeFrames(splitInto(await encodeToWire(packet), 1))
+    expect(frames).toHaveLength(1)
+    expect(frames[0]).toEqual(packet)
+  })
+
+  it('decodes two consecutive frames in order', async () => {
+    const a = pattern(5000, 1)
+    const b = pattern(3500, 2)
+    const frames = await decodeFrames([await encodeToWire(a, b)])
+    expect(frames).toHaveLength(2)
+    expect(frames[0]).toEqual(a)
+    expect(frames[1]).toEqual(b)
+  })
+})

--- a/packages/core/src/network/mtproxy/_fake-tls.test.ts
+++ b/packages/core/src/network/mtproxy/_fake-tls.test.ts
@@ -125,4 +125,36 @@ describe('FakeTlsPacketCodec', () => {
     expect(frames[0]).toEqual(a)
     expect(frames[1]).toEqual(b)
   })
+
+  it('decodes two frames packed into a single TLS record (inner-codec drain path)', async () => {
+    // Both inner-encoded frames (4 + 100 bytes each) fit in one record, so the
+    // second frame surfaces only via the post-loop inner-codec drain.
+    const a = pattern(100, 1)
+    const b = pattern(100, 2)
+    const frames = await decodeFrames([await encodeToWire(a, b)])
+    expect(frames).toHaveLength(2)
+    expect(frames[0]).toEqual(a)
+    expect(frames[1]).toEqual(b)
+  })
+
+  it('round-trips when the final record is exactly full', async () => {
+    // 4 + payload is an exact multiple of MAX_TLS_PACKET_LENGTH, so the last
+    // record is exactly `length` bytes — pins the `reader.available < length` edge.
+    const packet = pattern(2878 * 2 - 4, 7)
+    const frames = await decodeFrames([await encodeToWire(packet)])
+    expect(frames).toHaveLength(1)
+    expect(frames[0]).toEqual(packet)
+  })
+
+  it('throws on a corrupt TLS record header', async () => {
+    const codec = new FakeTlsPacketCodec(await makeStatefulInner())
+    const corrupt = Bytes.from(new Uint8Array([0x16, 0x03, 0x03, 0x00, 0x01, 0xFF]))
+    await expect(codec.decode(corrupt, false)).rejects.toThrow('Invalid TLS header')
+  })
+
+  it('returns null on eof', async () => {
+    const codec = new FakeTlsPacketCodec(await makeStatefulInner())
+    const buf = Bytes.from(new Uint8Array([0x17, 0x03, 0x03, 0x00, 0x01, 0xFF]))
+    expect(await codec.decode(buf, true)).toBe(null)
+  })
 })

--- a/packages/core/src/network/mtproxy/_fake-tls.test.ts
+++ b/packages/core/src/network/mtproxy/_fake-tls.test.ts
@@ -1,7 +1,7 @@
 import type { ISyncWritable } from '@fuman/io'
+import type { IAesCtr, ICryptoProvider } from '../../utils/index.js'
 import type { IPacketCodec } from '../transports/index.js'
 import { Bytes, write } from '@fuman/io'
-import { u8 } from '@fuman/utils'
 import { defaultTestCryptoProvider } from '@mtcute/test'
 import { describe, expect, it } from 'vitest'
 
@@ -12,64 +12,48 @@ import { FakeTlsPacketCodec } from './_fake-tls.js'
 // layer) over a uint32le length-prefixed framer. AES-CTR is non-rewindable, so
 // this reproduces the corruption the buggy decode caused by rewinding a record
 // it had already fed to the inner codec — a stateless inner would not surface it.
-async function makeStatefulInner(): Promise<IPacketCodec> {
-  const crypto = await defaultTestCryptoProvider()
-  const key = new Uint8Array(32).fill(0x2B)
-  const iv = new Uint8Array(16).fill(0x17)
-  const enc = crypto.createAesCtr(key, iv, true)
-  const dec = crypto.createAesCtr(key, iv, false)
-  let acc = new Uint8Array(0)
+class StatefulInnerCodec implements IPacketCodec {
+  readonly #enc: IAesCtr
+  readonly #dec: IAesCtr
+  #acc = new Uint8Array(0)
 
-  return {
-    setup() {},
-    tag: async () => new Uint8Array(0),
-    reset() {},
-    async encode(packet: Uint8Array, into: ISyncWritable): Promise<void> {
-      const framed = new Uint8Array(4 + packet.length)
-      new DataView(framed.buffer).setUint32(0, packet.length, true)
-      framed.set(packet, 4)
-      write.bytes(into, enc.process(framed))
-    },
-    async decode(reader: Bytes): Promise<Uint8Array | null> {
-      if (reader.available > 0) {
-        acc = u8.concat2(acc, dec.process(reader.readSync(reader.available)))
-      }
-      if (acc.length < 4) return null
-      const length = new DataView(acc.buffer, acc.byteOffset, acc.byteLength).getUint32(0, true)
-      if (acc.length - 4 < length) return null
-      const out = acc.slice(4, 4 + length)
-      acc = acc.slice(4 + length)
-      return out
-    },
-  } as unknown as IPacketCodec
-}
-
-async function encodeToWire(...packets: Uint8Array[]): Promise<Uint8Array> {
-  const codec = new FakeTlsPacketCodec(await makeStatefulInner())
-  // Set `_tag` to empty so encode does not prepend the obfuscation handshake tag
-  // (in the real flow that is exchanged out of band, never inside a framed payload).
-  await codec.tag()
-  const into = Bytes.alloc(packets.reduce((n, p) => n + p.length, 0) + 256)
-  for (const p of packets) await codec.encode(p, into)
-  return into.result().slice()
-}
-
-// Mirrors @fuman/io FramedReader.read: append a chunk, drain frames via
-// decode()+reclaim() until decode returns null, then read the next chunk.
-async function decodeFrames(chunks: Uint8Array[]): Promise<Uint8Array[]> {
-  const codec = new FakeTlsPacketCodec(await makeStatefulInner())
-  const buffer = Bytes.alloc(64)
-  const frames: Uint8Array[] = []
-  for (const chunk of chunks) {
-    write.bytes(buffer, chunk)
-    for (;;) {
-      const frame = await codec.decode(buffer, false)
-      buffer.reclaim()
-      if (frame === null) break
-      frames.push(frame)
-    }
+  constructor(crypto: ICryptoProvider) {
+    const key = new Uint8Array(32).fill(0x2B)
+    const iv = new Uint8Array(16).fill(0x17)
+    this.#enc = crypto.createAesCtr(key, iv, true)
+    this.#dec = crypto.createAesCtr(key, iv, false)
   }
-  return frames
+
+  tag(): Uint8Array {
+    return new Uint8Array(0)
+  }
+
+  reset(): void {
+    this.#acc = new Uint8Array(0)
+  }
+
+  encode(packet: Uint8Array, into: ISyncWritable): void {
+    const framed = new Uint8Array(4 + packet.length)
+    new DataView(framed.buffer).setUint32(0, packet.length, true)
+    framed.set(packet, 4)
+    write.bytes(into, this.#enc.process(framed))
+  }
+
+  decode(reader: Bytes): Uint8Array | null {
+    if (reader.available > 0) {
+      const chunk = this.#dec.process(reader.readSync(reader.available))
+      const next = new Uint8Array(this.#acc.length + chunk.length)
+      next.set(this.#acc)
+      next.set(chunk, this.#acc.length)
+      this.#acc = next
+    }
+    if (this.#acc.length < 4) return null
+    const length = new DataView(this.#acc.buffer, this.#acc.byteOffset, this.#acc.byteLength).getUint32(0, true)
+    if (this.#acc.length - 4 < length) return null
+    const out = this.#acc.slice(4, 4 + length)
+    this.#acc = this.#acc.slice(4 + length)
+    return out
+  }
 }
 
 function pattern(size: number, seed = 0): Uint8Array {
@@ -84,7 +68,37 @@ function splitInto(wire: Uint8Array, chunk: number): Uint8Array[] {
   return out
 }
 
-describe('FakeTlsPacketCodec', () => {
+describe('FakeTlsPacketCodec', async () => {
+  const crypto = await defaultTestCryptoProvider()
+
+  async function encodeToWire(...packets: Uint8Array[]): Promise<Uint8Array> {
+    const codec = new FakeTlsPacketCodec(new StatefulInnerCodec(crypto))
+    // Set `_tag` to empty so encode does not prepend the obfuscation handshake tag
+    // (in the real flow that is exchanged out of band, never inside a framed payload).
+    await codec.tag()
+    const into = Bytes.alloc(packets.reduce((n, p) => n + p.length, 0) + 256)
+    for (const p of packets) await codec.encode(p, into)
+    return into.result().slice()
+  }
+
+  // Mirrors @fuman/io FramedReader.read: append a chunk, drain frames via
+  // decode()+reclaim() until decode returns null, then read the next chunk.
+  async function decodeFrames(chunks: Uint8Array[]): Promise<Uint8Array[]> {
+    const codec = new FakeTlsPacketCodec(new StatefulInnerCodec(crypto))
+    const buffer = Bytes.alloc(64)
+    const frames: Uint8Array[] = []
+    for (const chunk of chunks) {
+      write.bytes(buffer, chunk)
+      for (;;) {
+        const frame = await codec.decode(buffer, false)
+        buffer.reclaim()
+        if (frame === null) break
+        frames.push(frame)
+      }
+    }
+    return frames
+  }
+
   it('round-trips a small response that fits in one TLS record', async () => {
     const packet = pattern(120)
     const frames = await decodeFrames([await encodeToWire(packet)])
@@ -147,13 +161,13 @@ describe('FakeTlsPacketCodec', () => {
   })
 
   it('throws on a corrupt TLS record header', async () => {
-    const codec = new FakeTlsPacketCodec(await makeStatefulInner())
+    const codec = new FakeTlsPacketCodec(new StatefulInnerCodec(crypto))
     const corrupt = Bytes.from(new Uint8Array([0x16, 0x03, 0x03, 0x00, 0x01, 0xFF]))
     await expect(codec.decode(corrupt, false)).rejects.toThrow('Invalid TLS header')
   })
 
   it('returns null on eof', async () => {
-    const codec = new FakeTlsPacketCodec(await makeStatefulInner())
+    const codec = new FakeTlsPacketCodec(new StatefulInnerCodec(crypto))
     const buf = Bytes.from(new Uint8Array([0x17, 0x03, 0x03, 0x00, 0x01, 0xFF]))
     expect(await codec.decode(buf, true)).toBe(null)
   })

--- a/packages/core/src/network/mtproxy/_fake-tls.ts
+++ b/packages/core/src/network/mtproxy/_fake-tls.ts
@@ -7,6 +7,9 @@ import { Bytes, read } from '@fuman/io'
 import { bigint, typed, u8 } from '@fuman/utils'
 
 const MAX_TLS_PACKET_LENGTH = 2878
+// modern chrome client hello (with X25519MLKEM768 keyshare) is ~1500-1700 bytes;
+// allocate generously and slice to the actual length afterwards
+const MAX_TLS_HELLO_SIZE = 4096
 
 // ref: https://github.com/tdlib/td/blob/master/td/mtproto/TlsInit.cpp
 const KEY_MOD = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEDn
@@ -47,52 +50,95 @@ function _isQuadraticResidue(a: bigint): boolean {
   return r === 1n
 }
 
+/* eslint-disable antfu/consistent-list-newline */
 function executeTlsOperations(h: TlsHelloWriter): void {
-  h.string([0x16, 0x03, 0x01, 0x02, 0x00, 0x01, 0x00, 0x01, 0xFC, 0x03, 0x03])
-  h.zero(32)
+  h.string([0x16, 0x03, 0x01])
+  h.beginScope() // record length
+  h.string([0x01, 0x00]) // handshake type (client hello) + high byte of 24-bit length
+  h.beginScope() // handshake length (low 16 bits)
+  h.string([0x03, 0x03]) // client version
+  h.zero(32) // digest slot (hmac written here, at offset 11)
   h.string([0x20])
-  h.random(32)
+  h.random(32) // session id
   h.string([0x00, 0x20])
   h.grease(0)
-  /* eslint-disable antfu/consistent-list-newline */
   h.string([
     0x13, 0x01, 0x13, 0x02, 0x13, 0x03, 0xC0, 0x2B, 0xC0, 0x2F, 0xC0, 0x2C,
     0xC0, 0x30, 0xCC, 0xA9, 0xCC, 0xA8, 0xC0, 0x13, 0xC0, 0x14, 0x00, 0x9C,
-    0x00, 0x9D, 0x00, 0x2F, 0x00, 0x35, 0x01, 0x00, 0x01, 0x93,
-  ])
+    0x00, 0x9D, 0x00, 0x2F, 0x00, 0x35, 0x01, 0x00,
+  ]) // cipher suites + compression methods (null)
+  h.beginScope() // extensions length
   h.grease(2)
-  h.string([0x00, 0x00, 0x00, 0x00])
-  h.beginScope()
-  h.beginScope()
-  h.string([0x00])
-  h.beginScope()
-  h.domain()
-  h.endScope()
-  h.endScope()
-  h.endScope()
-  h.string([0x00, 0x17, 0x00, 0x00, 0xFF, 0x01, 0x00, 0x01, 0x00, 0x00, 0x0A, 0x00, 0x0A, 0x00, 0x08])
-  h.grease(4)
-  h.string(
-    [
-      0x00, 0x1D, 0x00, 0x17, 0x00, 0x18, 0x00, 0x0B, 0x00, 0x02, 0x01, 0x00,
-      0x00, 0x23, 0x00, 0x00, 0x00, 0x10, 0x00, 0x0E, 0x00, 0x0C, 0x02, 0x68,
-      0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2F, 0x31, 0x2E, 0x31, 0x00, 0x05,
-      0x00, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0D, 0x00, 0x12, 0x00,
-      0x10, 0x04, 0x03, 0x08, 0x04, 0x04, 0x01, 0x05, 0x03, 0x08, 0x05, 0x05,
-      0x01, 0x08, 0x06, 0x06, 0x01, 0x00, 0x12, 0x00, 0x00, 0x00, 0x33, 0x00,
-      0x2B, 0x00, 0x29,
-    ],
-  )
-  h.grease(4)
-  h.string([0x00, 0x01, 0x00, 0x00, 0x1D, 0x00, 0x20])
-  h.key()
-  h.string([0x00, 0x2D, 0x00, 0x02, 0x01, 0x01, 0x00, 0x2B, 0x00, 0x0B, 0x0A])
-  h.grease(6)
-  h.string([0x03, 0x04, 0x03, 0x03, 0x03, 0x02, 0x03, 0x01, 0x00, 0x1B, 0x00, 0x03, 0x02, 0x00, 0x02])
+  h.string([0x00, 0x00])
+  h.permutation([
+    (w) => { // server_name (SNI)
+      w.string([0x00, 0x00])
+      w.beginScope()
+      w.beginScope()
+      w.string([0x00])
+      w.beginScope()
+      w.domain()
+      w.endScope()
+      w.endScope()
+      w.endScope()
+    },
+    w => w.string([0x00, 0x05, 0x00, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00]), // status_request
+    (w) => { // supported_groups
+      w.string([0x00, 0x0A, 0x00, 0x0C, 0x00, 0x0A])
+      w.grease(4)
+      w.string([0x11, 0xEC, 0x00, 0x1D, 0x00, 0x17, 0x00, 0x18])
+    },
+    w => w.string([0x00, 0x0B, 0x00, 0x02, 0x01, 0x00]), // ec_point_formats
+    w => w.string([ // signature_algorithms
+      0x00, 0x0D, 0x00, 0x12, 0x00, 0x10, 0x04, 0x03, 0x08, 0x04, 0x04, 0x01,
+      0x05, 0x03, 0x08, 0x05, 0x05, 0x01, 0x08, 0x06, 0x06, 0x01,
+    ]),
+    w => w.string([ // application_layer_protocol_negotiation (ALPN)
+      0x00, 0x10, 0x00, 0x0E, 0x00, 0x0C, 0x02, 0x68, 0x32, 0x08, 0x68, 0x74,
+      0x74, 0x70, 0x2F, 0x31, 0x2E, 0x31,
+    ]),
+    w => w.string([0x00, 0x12, 0x00, 0x00]), // signed_certificate_timestamp
+    w => w.string([0x00, 0x17, 0x00, 0x00]), // extended_master_secret
+    w => w.string([0x00, 0x1B, 0x00, 0x03, 0x02, 0x00, 0x02]), // compress_certificate
+    w => w.string([0x00, 0x23, 0x00, 0x00]), // session_ticket
+    (w) => { // supported_versions
+      w.string([0x00, 0x2B, 0x00, 0x07, 0x06])
+      w.grease(6)
+      w.string([0x03, 0x04, 0x03, 0x03])
+    },
+    w => w.string([0x00, 0x2D, 0x00, 0x02, 0x01, 0x01]), // psk_key_exchange_modes
+    (w) => { // key_share
+      w.string([0x00, 0x33, 0x04, 0xEF, 0x04, 0xED])
+      w.grease(4)
+      w.string([0x00, 0x01, 0x00, 0x11, 0xEC, 0x04, 0xC0])
+      w.mlKem768Key()
+      w.key()
+      w.string([0x00, 0x1D, 0x00, 0x20])
+      w.key()
+    },
+    w => w.string([0x44, 0xCD, 0x00, 0x05, 0x00, 0x03, 0x02, 0x68, 0x32]), // application_settings (ALPS)
+    (w) => { // encrypted_client_hello (GREASE)
+      w.string([0xFE, 0x0D])
+      w.beginScope()
+      w.string([0x00, 0x00, 0x01, 0x00, 0x01])
+      w.random(1)
+      w.string([0x00, 0x20])
+      w.random(32)
+      w.beginScope()
+      w.echPayload()
+      w.endScope()
+      w.endScope()
+    },
+    w => w.string([0xFF, 0x01, 0x00, 0x01, 0x00]), // renegotiation_info
+  ])
   h.grease(3)
-  h.string([0x00, 0x01, 0x00, 0x00, 0x15])
-  /* eslint-enable */
+  h.string([0x00, 0x01, 0x00])
+  h.padding()
+  h.endScope() // extensions
+  h.endScope() // handshake
+  h.endScope() // record
 }
+/* eslint-enable antfu/consistent-list-newline */
 
 function initGrease(crypto: ICryptoProvider, size: number): Uint8Array {
   const buf = crypto.randomBytes(size)
@@ -116,44 +162,45 @@ class TlsHelloWriter {
   pos = 0
 
   private _domain: Uint8Array
-  private _grease
+  private _grease: Uint8Array
   private _scopes: number[] = []
 
   constructor(
     readonly crypto: ICryptoProvider,
-    size: number,
     domain: Uint8Array,
+    grease?: Uint8Array,
   ) {
     this._domain = domain
-    this.buf = u8.alloc(size)
+    this.buf = u8.alloc(MAX_TLS_HELLO_SIZE)
     this.dv = typed.toDataView(this.buf)
-    this._grease = initGrease(this.crypto, 7)
+    // shared across permutation sub-writers so grease seeds stay consistent
+    this._grease = grease ?? initGrease(this.crypto, 7)
   }
 
-  string(buf: ArrayLike<number>) {
+  string(buf: ArrayLike<number>): void {
     this.buf.set(buf, this.pos)
     this.pos += buf.length
   }
 
-  random(size: number) {
+  random(size: number): void {
     this.string(this.crypto.randomBytes(size))
   }
 
-  zero(size: number) {
+  zero(size: number): void {
     // since the Uint8Array is initialized with zeros, we can just skip
     this.pos += size
   }
 
-  domain() {
+  domain(): void {
     this.string(this._domain)
   }
 
-  grease(seed: number) {
+  grease(seed: number): void {
     this.buf[this.pos] = this.buf[this.pos + 1] = this._grease[seed]
     this.pos += 2
   }
 
-  key() {
+  key(): void {
     for (;;) {
       const key = this.crypto.randomBytes(32)
       key[31] &= 127
@@ -174,41 +221,92 @@ class TlsHelloWriter {
     }
   }
 
-  beginScope() {
+  // fake X25519MLKEM768 hybrid keyshare's ml-kem-768 part: 384 coefficients
+  // (mod 3329) packed 3 bytes per 2 coefficients, followed by 32 random bytes
+  mlKem768Key(): void {
+    const rnd = this.crypto.randomBytes(384 * 8)
+    const dv = typed.toDataView(rnd)
+
+    for (let i = 0; i < 384; i++) {
+      const a = dv.getUint32(i * 8, true) % 3329
+      const b = dv.getUint32(i * 8 + 4, true) % 3329
+      this.buf[this.pos++] = a & 0xFF
+      this.buf[this.pos++] = (a >> 8) + ((b & 0x0F) << 4)
+      this.buf[this.pos++] = b >> 4
+    }
+
+    this.random(32)
+  }
+
+  // GREASE ECH payload: random bytes of length 144/176/208/240
+  echPayload(): void {
+    this.random(this._randomInt(4) * 32 + 144)
+  }
+
+  beginScope(): void {
     this._scopes.push(this.pos)
     this.pos += 2
   }
 
-  endScope() {
+  endScope(): void {
     const begin = this._scopes.pop()
 
     if (begin === undefined) {
       throw new Error('endScope called without beginScope')
     }
 
-    const end = this.pos
-    const size = end - begin - 2
+    this.dv.setUint16(begin, this.pos - begin - 2)
+  }
 
-    this.dv.setUint16(begin, size)
+  // render each part into its own buffer, then emit them in random order —
+  // mimics chrome's per-connection tls extension shuffling
+  permutation(parts: Array<(w: TlsHelloWriter) => void>): void {
+    const rendered = parts.map((fn) => {
+      const sub = new TlsHelloWriter(this.crypto, this._domain, this._grease)
+      fn(sub)
+      return sub.buf.subarray(0, sub.pos)
+    })
+
+    for (let i = rendered.length - 1; i > 0; i--) {
+      const j = this._randomInt(i + 1)
+      const tmp = rendered[i]
+      rendered[i] = rendered[j]
+      rendered[j] = tmp
+    }
+
+    for (const part of rendered) {
+      this.string(part)
+    }
+  }
+
+  // tls padding extension, only emitted for hellos smaller than 513 bytes
+  padding(): void {
+    if (this.pos >= 513) return
+
+    const size = 513 - this.pos
+    this.string([0x00, 0x15])
+    this.beginScope()
+    this.zero(size)
+    this.endScope()
+  }
+
+  private _randomInt(max: number): number {
+    return typed.toDataView(this.crypto.randomBytes(4)).getUint32(0, true) % max
   }
 
   async finish(secret: Uint8Array): Promise<Uint8Array> {
-    const padSize = 515 - this.pos
+    const data = this.buf.subarray(0, this.pos)
     const unixTime = ~~(Date.now() / 1000)
 
-    this.beginScope()
-    this.zero(padSize)
-    this.endScope()
-
-    const hash = await this.crypto.hmacSha256(this.buf, secret)
+    const hash = await this.crypto.hmacSha256(data, secret)
     const dv = typed.toDataView(hash)
 
     const old = dv.getInt32(28, true)
     dv.setInt32(28, old ^ unixTime, true)
 
-    this.buf.set(hash, 11)
+    data.set(hash, 11)
 
-    return this.buf
+    return data
   }
 }
 
@@ -217,7 +315,7 @@ export async function generateFakeTlsHeader(
   secret: Uint8Array,
   crypto: ICryptoProvider,
 ): Promise<Uint8Array> {
-  const writer = new TlsHelloWriter(crypto, 517, domain)
+  const writer = new TlsHelloWriter(crypto, domain)
   executeTlsOperations(writer)
 
   return writer.finish(secret)

--- a/packages/core/src/network/mtproxy/_fake-tls.ts
+++ b/packages/core/src/network/mtproxy/_fake-tls.ts
@@ -7,6 +7,7 @@ import { Bytes, read } from '@fuman/io'
 import { bigint, typed, u8 } from '@fuman/utils'
 
 const MAX_TLS_PACKET_LENGTH = 2878
+const EMPTY = new Uint8Array(0)
 
 // ref: https://github.com/tdlib/td/blob/master/td/mtproto/TlsInit.cpp
 const KEY_MOD = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEDn
@@ -270,28 +271,34 @@ export class FakeTlsPacketCodec implements IPacketCodec {
 
   async decode(reader: Bytes, eof: boolean): Promise<Uint8Array | null> {
     if (eof) return null
-    if (reader.available < 5) return null
 
-    const header = reader.readSync(3)
-    if (header[0] !== 0x17 || header[1] !== 0x03 || header[2] !== 0x03) {
-      throw new Error('Invalid TLS header')
+    // A single inner frame is sliced across multiple TLS records by `encode`,
+    // and those records usually arrive coalesced, so we must consume every
+    // complete record buffered this call and feed each to the inner codec until
+    // it yields a frame. The inner codec is stateful (obfuscation runs an AES-CTR
+    // stream cipher), so a record, once fed, is consumed for good — it must never
+    // be rewound, or the same ciphertext is decrypted twice at different keystream
+    // offsets and the stream desyncs (surfaces as `invalid messageKey`).
+    while (reader.available >= 5) {
+      const header = reader.readSync(3)
+      if (header[0] !== 0x17 || header[1] !== 0x03 || header[2] !== 0x03) {
+        throw new Error('Invalid TLS header')
+      }
+
+      const length = read.uint16be(reader)
+      if (reader.available < length) {
+        // incomplete trailing record — nothing was fed yet, wait for more data
+        reader.rewind(5)
+        break
+      }
+
+      const inner = await this._inner.decode(Bytes.from(reader.readSync(length)), eof)
+      if (inner) return inner
     }
 
-    const length = read.uint16be(reader)
-    if (length < reader.available - 5) {
-      reader.rewind(5)
-      return null
-    }
-
-    const packet = reader.readSync(length)
-    const inner = await this._inner.decode(Bytes.from(packet), eof)
-
-    if (!inner) {
-      reader.rewind(5 + length)
-      return null
-    }
-
-    return inner
+    // no fresh record produced a frame — drain a frame that may already be
+    // buffered inside the (stateful) inner codec
+    return this._inner.decode(Bytes.from(EMPTY), eof)
   }
 
   reset(): void {

--- a/packages/core/src/network/mtproxy/_fake-tls.ts
+++ b/packages/core/src/network/mtproxy/_fake-tls.ts
@@ -7,7 +7,6 @@ import { Bytes, read } from '@fuman/io'
 import { bigint, typed, u8 } from '@fuman/utils'
 
 const MAX_TLS_PACKET_LENGTH = 2878
-const EMPTY = new Uint8Array(0)
 
 // ref: https://github.com/tdlib/td/blob/master/td/mtproto/TlsInit.cpp
 const KEY_MOD = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEDn
@@ -224,6 +223,8 @@ export async function generateFakeTlsHeader(
   return writer.finish(secret)
 }
 
+const EMPTY_BYTES = Bytes.from(u8.empty)
+
 /**
  * Fake TLS packet codec, used for some MTProxies.
  *
@@ -272,13 +273,9 @@ export class FakeTlsPacketCodec implements IPacketCodec {
   async decode(reader: Bytes, eof: boolean): Promise<Uint8Array | null> {
     if (eof) return null
 
-    // A single inner frame is sliced across multiple TLS records by `encode`,
-    // and those records usually arrive coalesced, so we must consume every
-    // complete record buffered this call and feed each to the inner codec until
-    // it yields a frame. The inner codec is stateful (obfuscation runs an AES-CTR
-    // stream cipher), so a record, once fed, is consumed for good — it must never
-    // be rewound, or the same ciphertext is decrypted twice at different keystream
-    // offsets and the stream desyncs (surfaces as `invalid messageKey`).
+    // a single inner frame can be sliced across multiple TLS records.
+    // we need to feed as much as possible into the inner codec until it actually yields a frame.
+    // a bit of an abstraction leak, relying on the inner codec to be stateful, but whatever.
     while (reader.available >= 5) {
       const header = reader.readSync(3)
       if (header[0] !== 0x17 || header[1] !== 0x03 || header[2] !== 0x03) {
@@ -287,7 +284,7 @@ export class FakeTlsPacketCodec implements IPacketCodec {
 
       const length = read.uint16be(reader)
       if (reader.available < length) {
-        // incomplete trailing record — nothing was fed yet, wait for more data
+        // incomplete trailing record - wait for more data
         reader.rewind(5)
         break
       }
@@ -296,9 +293,8 @@ export class FakeTlsPacketCodec implements IPacketCodec {
       if (inner) return inner
     }
 
-    // no fresh record produced a frame — drain a frame that may already be
-    // buffered inside the (stateful) inner codec
-    return this._inner.decode(Bytes.from(EMPTY), eof)
+    // try draining the inner codec
+    return this._inner.decode(EMPTY_BYTES, eof)
   }
 
   reset(): void {


### PR DESCRIPTION
Fixes #141.

### Problem

`FakeTlsPacketCodec.decode` corrupts or drops any MTProto response large enough to span multiple TLS records (`messages.getReplies`, `updates.getDifference`, `langpack.getLangPack`). Small responses work, large ones throw `Invalid TLS header`, then `invalid messageKey`, then a permanent `didn't receive pong` reconnect loop — so a fake-TLS MTProxy can't read channel history at all.

### Cause

`encode` slices a single inner frame across multiple ≤`MAX_TLS_PACKET_LENGTH` TLS records, and they usually arrive coalesced. The old `decode`:

1. `if (length < reader.available - 5)` is inverted — it returns `null` when **more than one** record is buffered (the coalesced large case), instead of when a record is **incomplete**, so it never makes progress.
2. `reader.rewind(5 + length)` rewinds a record **after** feeding it to the inner `ObfuscatedPacketCodec` (an AES-CTR stream cipher). On the next `FramedReader` pass the same ciphertext is decrypted again at an advanced keystream offset → the stream desyncs → `invalid messageKey`.

`@fuman/io`'s `FramedReader.read` calls `decode` once, `reclaim()`s, and only calls it again after a frame is returned or more TCP arrives — so a single `decode` call must drain every complete record of a frame.

### Fix

`decode` now consumes every complete record buffered this call, feeds each exactly once, never rewinds a fed record (only an incomplete trailing one), and finally drains a frame that may already be buffered inside the inner codec.

### Tests

New `_fake-tls.test.ts` round-trips through a stateful (AES-CTR) inner codec — the statefulness is what makes the rewind bug observable; a stateless inner would hide it. Covers small/coalesced/mid-stream-split/byte-by-byte/two-frame deliveries. It **fails on the previous decode** (4/5 cases, the small one still passes) and passes with this change. `pnpm test -- packages/core/src/network` is green (95 tests).

Also verified end-to-end against a real fake-TLS MTProxy: before, `langpack.getLangPack` (~1 MB) threw `Invalid TLS header`; after, it decodes cleanly (10 920 strings), while `help.getConfig` (~1 record) succeeds either way.
