### PR TITLE
fix(core): preserve spoiler when sending a photo via messages.uploadMedia

### DIFF
--- a/packages/core/src/highlevel/methods/files/normalize-input-media.ts
+++ b/packages/core/src/highlevel/methods/files/normalize-input-media.ts
@@ -342,7 +342,7 @@ export async function _normalizeInputMedia(
           fileReference: res.photo.fileReference,
         },
         ttlSeconds: media.ttlSeconds,
-        spoiler: media.type === 'video' && media.spoiler,
+        spoiler: media.spoiler,
         livePhoto: Boolean(livePhotoVideo),
         video: livePhotoVideo,
       }


### PR DESCRIPTION
## Problem

When a photo is sent with `spoiler: true` and the media goes through the
`messages.uploadMedia` path (`uploadMedia: true` — e.g. albums / media groups,
or any caller that pre-uploads media), the spoiler flag is silently dropped and
the photo is delivered without a spoiler.

## Root cause

In `_normalizeInputMedia`, the inner `uploadMediaIfNeeded` helper re-normalizes
the result of `messages.uploadMedia`. The photo branch hardcodes:

```ts
spoiler: media.type === 'video' && media.spoiler,
```

But this branch only runs when photo === true, and all three call sites pass
photo: true exclusively when media.type === 'photo' (the
inputMediaUploadedPhoto, inputMediaPhotoExternal, and fileId-photo paths).
So media.type === 'video' is always false here and the spoiler is never set.

This is inconsistent with the non-uploadMedia photo paths, which correctly
carry the spoiler (e.g. inputMediaUploadedPhoto uses spoiler: media.spoiler,
and the fileId path computes (media.type === 'video' || media.type === 'photo') && media.spoiler).

## Fix

In the photo branch of uploadMediaIfNeeded, set spoiler: media.spoiler
directly — matching how inputMediaUploadedPhoto is built a few lines below.
The document branch (photo === false) is unchanged, since a photo can never
reach it.

## Repro

Send a photo with a spoiler to a peer that requires pre-upload (or via a media
group): before this change the spoiler is missing; after, it's preserved.