### PR TITLE
Fix memory growth in obfuscated transport decode buffer

### DIFF
--- a/packages/core/src/network/transports/obfuscated.test.ts
+++ b/packages/core/src/network/transports/obfuscated.test.ts
@@ -1,3 +1,4 @@
+import type { IPacketCodec } from './abstract.js'
 import type { MtProxyInfo } from './obfuscated.js'
 import { Bytes } from '@fuman/io'
 import { hex } from '@fuman/utils'
@@ -197,5 +198,31 @@ describe('ObfuscatedPacketCodec', () => {
     codec.reset()
 
     expect(spyInnerReset).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not retain consumed decode bytes', async () => {
+    const inner: IPacketCodec = {
+      tag: () => new Uint8Array([0xEE, 0xEE, 0xEE, 0xEE]),
+      decode: reader => new Uint8Array(reader.readSync(reader.available)),
+      encode: () => {},
+      reset: () => {},
+    }
+
+    const codec = new ObfuscatedPacketCodec(inner)
+    codec.setup(await defaultTestCryptoProvider(), new LogManager(undefined, defaultPlatform))
+
+    await codec.tag()
+
+    // @ts-expect-error - reading private
+    const decodeBuf = codec._decodeBuf
+    const initialCapacity = decodeBuf.capacity
+
+    for (let i = 0; i < 3000; i++) {
+      await codec.decode(Bytes.from(new Uint8Array(8)), false)
+    }
+
+    expect(decodeBuf.available).toBe(0)
+    expect(decodeBuf.written).toBe(0)
+    expect(decodeBuf.capacity).toBe(initialCapacity)
   })
 })

--- a/packages/core/src/network/transports/obfuscated.ts
+++ b/packages/core/src/network/transports/obfuscated.ts
@@ -111,7 +111,10 @@ export class ObfuscatedPacketCodec implements IPacketCodec {
       into.set(this._decryptor!.process(reader.readSync(reader.available)))
     }
 
-    return this._inner.decode(this._decodeBuf, eof)
+    const packet = await this._inner.decode(this._decodeBuf, eof)
+    this._decodeBuf.reclaim()
+
+    return packet
   }
 
   reset(): void {


### PR DESCRIPTION
While investigating production memory growth, I took a few heap snapshots and found that `ObfuscatedPacketCodec` could retain already-consumed bytes in `_decodeBuf`.

I'm not fully sure this is the correct fix, but I tested it in production and it made external memory growth much flatter (though not fully flat).

<img width="1242" height="520" alt="image" src="https://github.com/user-attachments/assets/e2becd16-ea1f-4faa-a760-027a9bb5ade4" />

I will continue investigating other memory issues separately.