### PR TITLE
fix(core): `editForumTopic` — `icon: null` now removes the topic icon

### DIFF
--- a/packages/core/src/highlevel/methods/forums/edit-forum-topic.ts
+++ b/packages/core/src/highlevel/methods/forums/edit-forum-topic.ts
@@ -57,7 +57,7 @@ export async function editForumTopic(
     peer: await resolvePeer(client, chatId),
     topicId: typeof topicId === 'number' ? topicId : topicId.id,
     title,
-    iconEmojiId: icon ? icon ?? Long.ZERO : undefined,
+    iconEmojiId: icon === null ? Long.ZERO : icon,
     closed,
     hidden,
   })


### PR DESCRIPTION

## Problem

`editForumTopic`'s `icon` param is documented as accepting `null` to remove a custom emoji icon:

```ts
/**
 * New icon of the topic.
 *
 * Can be a custom emoji ID, or `null` to remove the icon
 * and use static color instead
 */
icon?: tl.Long | null
```

However, the implementation contained a dead `?? Long.ZERO`:

```ts
iconEmojiId: icon ? icon ?? Long.ZERO : undefined,
```

When `icon` is `null` (falsy), the ternary short-circuits to `undefined`, so `icon_emoji_id` is never included in the `messages.editForumTopic` request. The icon stays unchanged — a silent no-op.

## Root cause

The `?? Long.ZERO` was intended to fire when `icon` is `null`, but it was guarded by a truthy check (`icon ?`), making it unreachable. The ternary couldn't distinguish "not passed" (`undefined`) from "explicitly remove" (`null`).

## Fix

```diff
-    iconEmojiId: icon ? icon ?? Long.ZERO : undefined,
+    iconEmojiId: icon === null ? Long.ZERO : icon,
```

| `icon` arg | Before | After |
|---|---|---|
| `undefined` | `undefined` (correct) | `undefined` (correct) |
| `Long` | the Long itself (correct) | the Long itself (correct) |
| `null` | `undefined` (**bug** — no-op) | `Long.ZERO` (**fixed** — icon removed) |

Single-line change, no API surface or type signature changes.