### PR TITLE
fix(core): reset asyncResettable after rejection

### DIFF
--- a/packages/core/src/utils/function-utils.test.ts
+++ b/packages/core/src/utils/function-utils.test.ts
@@ -1,7 +1,25 @@
 import { ConditionVariable } from '@fuman/utils'
 import { describe, expect, it } from 'vitest'
 
-import { throttle } from './function-utils.js'
+import { asyncResettable, throttle } from './function-utils.js'
+
+describe('asyncResettable', () => {
+  it('should allow retrying after a failed invocation', async () => {
+    const firstError = new Error('first invocation failed')
+    let invocations = 0
+    const resettable = asyncResettable(async () => {
+      invocations++
+      if (invocations === 1) throw firstError
+    })
+
+    await expect(resettable.run()).rejects.toBe(firstError)
+    expect(resettable.wait()).toBeNull()
+
+    await expect(resettable.run()).resolves.toBeUndefined()
+    expect(invocations).toBe(2)
+    expect(resettable.finished()).toBe(true)
+  })
+})
 
 describe('throttle', () => {
   it('should throttle', async () => {

--- a/packages/core/src/utils/function-utils.ts
+++ b/packages/core/src/utils/function-utils.ts
@@ -59,10 +59,15 @@ export function asyncResettable<T extends(...args: any[]) => Promise<any>>(func:
 
     // eslint-disable-next-line ts/no-unsafe-argument
     runningPromise = func(...args)
-    void runningPromise.then(() => {
-      runningPromise = null
-      finished = true
-    })
+    void runningPromise.then(
+      () => {
+        runningPromise = null
+        finished = true
+      },
+      () => {
+        runningPromise = null
+      },
+    )
 
     return runningPromise
   } as T


### PR DESCRIPTION
## Summary

- observe both settlement paths of the asyncResettable bookkeeping promise
- clear a rejected invocation so a later run can retry
- add regression coverage for rejection followed by a successful retry

## Why

The success-only then() call creates a second promise that rejects without an observer when the wrapped operation fails. The original rejected promise also remains cached, so every later run returns the same failure instead of retrying.

## Verification

- corepack pnpm test packages/core/src/utils/function-utils.test.ts
- corepack pnpm exec eslint packages/core/src/utils/function-utils.ts packages/core/src/utils/function-utils.test.ts
- corepack pnpm lint:tsc (after the same TL code generation used by CI)