### PR TITLE
fix(core): stop client continuations after destroy

### DIFF
--- a/packages/core/src/highlevel/base.test.ts
+++ b/packages/core/src/highlevel/base.test.ts
@@ -1,7 +1,43 @@
-import { StubTelegramClient } from '@mtcute/test'
-import { describe, expect, it } from 'vitest'
+import { createStub, StubTelegramClient } from '@mtcute/test'
+import { describe, expect, it, vi } from 'vitest'
 
 describe('BaseTelegramClient', () => {
+  describe('destroy', () => {
+    it('should reject an RPC response that arrives after destruction', async () => {
+      const client = new StubTelegramClient()
+      await client.connect()
+
+      const nearestDc = createStub('nearestDc')
+      let resolve!: (value: typeof nearestDc) => void
+      const response = new Promise<typeof nearestDc>((r) => {
+        resolve = r
+      })
+      vi.spyOn(client.mt, 'call').mockReturnValue(response)
+
+      const request = client.call({ _: 'help.getNearestDc' })
+      await client.destroy()
+      resolve(nearestDc)
+
+      await expect(request).rejects.toThrow('Client is destroyed')
+    })
+
+    it('should reject auth and DC continuations after destruction', async () => {
+      const client = new StubTelegramClient()
+      const notifyLoggedIn = vi.spyOn(client.mt.network, 'notifyLoggedIn')
+      const notifyLoggedOut = vi.spyOn(client.mt.network, 'notifyLoggedOut')
+      const changePrimaryDc = vi.spyOn(client.mt.network, 'changePrimaryDc')
+
+      await client.destroy()
+
+      await expect(client.notifyLoggedIn(createStub('user', { id: 1 }))).rejects.toThrow('Client is destroyed')
+      await expect(client.notifyLoggedOut()).rejects.toThrow('Client is destroyed')
+      await expect(client.changePrimaryDc(2)).rejects.toThrow('Client is destroyed')
+      expect(notifyLoggedIn).not.toHaveBeenCalled()
+      expect(notifyLoggedOut).not.toHaveBeenCalled()
+      expect(changePrimaryDc).not.toHaveBeenCalled()
+    })
+  })
+
   describe('string sessions', () => {
     it('should export session', async () => {
       const client = new StubTelegramClient()

--- a/packages/core/src/highlevel/base.ts
+++ b/packages/core/src/highlevel/base.ts
@@ -136,9 +136,11 @@ export class BaseTelegramClient implements ITelegramClient {
   // used in a hot path, avoid extra function calls
   private _connected = false
   private _connect = asyncResettable(async () => {
-    if (this.#destroyed) throw new Error('Client is destroyed')
+    this._assertNotDestroyed()
     await this._prepare.run()
+    this._assertNotDestroyed()
     await this.mt.connect()
+    this._assertNotDestroyed()
     this._connected = true
   })
 
@@ -179,33 +181,44 @@ export class BaseTelegramClient implements ITelegramClient {
     return this.#destroyed
   }
 
+  private _assertNotDestroyed(): void {
+    // Promise.race timeouts do not cancel their input. Keep this check on both sides of awaited
+    // reconnecting or state-mutating work so a late continuation cannot cross destroy().
+    if (this.#destroyed) throw new Error('Client is destroyed')
+  }
+
   [Symbol.asyncDispose](): Promise<void> {
     return this.destroy()
   }
 
   async notifyLoggedIn(auth: tl.auth.TypeAuthorization | tl.RawUser): Promise<tl.RawUser> {
+    this._assertNotDestroyed()
     const user = this.mt.network.notifyLoggedIn(auth)
 
     this.log.prefix = `[USER ${user.id}] `
     await this.storage.self.storeFrom(user)
 
+    this._assertNotDestroyed()
     this.updates?.notifyLoggedIn()
 
     return user
   }
 
   async notifyLoggedOut(): Promise<void> {
+    this._assertNotDestroyed()
     this.mt.network.notifyLoggedOut()
     this.updates?.notifyLoggedOut()
 
     this.log.prefix = '[USER n/a] '
     await this.storage.self.store(null)
+    this._assertNotDestroyed()
 
     // drop non-primary auth keys because they are no longer valid
     const primaryDc = this.mt.network.getPrimaryDcId()
     for (const dcId of [1, 2, 3, 4, 5]) { // lol
       if (dcId === primaryDc) continue
       await this.mt.storage.provider.authKeys.deleteByDc(dcId)
+      this._assertNotDestroyed()
     }
   }
 
@@ -238,11 +251,14 @@ export class BaseTelegramClient implements ITelegramClient {
     message: MustEqual<T, tl.RpcMethod>,
     params?: RpcCallOptions,
   ): Promise<tl.RpcCallReturn[T['_']]> {
+    this._assertNotDestroyed()
     if (!this._connected) {
       await this._connect.run()
     }
+    this._assertNotDestroyed()
 
     const res = await this.mt.call(message, params)
+    this._assertNotDestroyed()
 
     if (isTlRpcError(res)) {
       const error = makeRpcError(res, new Error().stack ?? '', message._)
@@ -251,6 +267,7 @@ export class BaseTelegramClient implements ITelegramClient {
     }
 
     await this.storage.peers.updatePeersFrom(res)
+    this._assertNotDestroyed()
 
     // eslint-disable-next-line ts/no-unsafe-return
     return res
@@ -372,8 +389,10 @@ export class BaseTelegramClient implements ITelegramClient {
     return this.mt.stopSignal
   }
 
-  changePrimaryDc(dcId: number): Promise<void> {
-    return this.mt.network.changePrimaryDc(dcId)
+  async changePrimaryDc(dcId: number): Promise<void> {
+    this._assertNotDestroyed()
+    await this.mt.network.changePrimaryDc(dcId)
+    this._assertNotDestroyed()
   }
 
   async getMtprotoMessageId(): Promise<Long> {


### PR DESCRIPTION
## Summary

- enforce the destroyed invariant around awaited connection and RPC work
- reject late auth notifications and primary-DC changes before they mutate client state
- document why lifecycle checks are needed on both sides of awaited work
- add regression coverage for late RPC responses and post-destroy auth/DC continuations

## Why

ITelegramClient documents that destroy() makes the client unusable. However, an application can stop awaiting a high-level method (for example, after Promise.race selects a timeout) and then destroy the client while the original promise is still running. That promise could later reconnect, update peer or auth state, change DC managers, or resolve successfully after teardown.

The guards make those late continuations reject with Client is destroyed instead. This is related to, but independent from, #155, which fixes rejected asyncResettable bookkeeping.

## Verification

- corepack pnpm test packages/core/src (697 passed, 2 skipped)
- corepack pnpm exec eslint packages/core/src/highlevel/base.ts packages/core/src/highlevel/base.test.ts
- corepack pnpm lint:tsc (after the same TL code generation used by CI)