### PR TITLE
fix(core): stop QR migration after abort

### DIFF
--- a/packages/core/src/highlevel/methods/auth/sign-in-qr.test.ts
+++ b/packages/core/src/highlevel/methods/auth/sign-in-qr.test.ts
@@ -1,0 +1,73 @@
+import type { tl } from '../../../tl/index.js'
+import { Deferred } from '@fuman/utils'
+import { StubTelegramClient } from '@mtcute/test'
+import { describe, expect, it, vi } from 'vitest'
+
+import { signInQr } from './sign-in-qr.js'
+
+describe('signInQr', () => {
+  it('should not change the primary DC if abort wins after export resolves', async () => {
+    const client = new StubTelegramClient()
+    const abort = new AbortController()
+    const exportCalled = new Deferred<void>()
+    const exportResponse = new Deferred<tl.auth.RawLoginTokenMigrateTo>()
+    const changePrimaryDc = vi.spyOn(client, 'changePrimaryDc').mockResolvedValue()
+    const call = vi.spyOn(client, 'call')
+
+    client.respondWith('auth.exportLoginToken', () => {
+      exportCalled.resolve()
+      return exportResponse.promise
+    })
+
+    const reason = new Error('controlled abort')
+    const result = signInQr(client, {
+      abortSignal: abort.signal,
+      onUrlUpdated: () => {},
+    })
+    const rejection = expect(result).rejects.toBe(reason)
+
+    await exportCalled.promise
+    exportResponse.resolve({
+      _: 'auth.loginTokenMigrateTo',
+      dcId: 2,
+      token: new Uint8Array(),
+    })
+    abort.abort(reason)
+
+    await rejection
+    expect(changePrimaryDc).not.toHaveBeenCalled()
+    expect(call).toHaveBeenCalledOnce()
+  })
+
+  it('should not import the token if aborted during the primary DC change', async () => {
+    const client = new StubTelegramClient()
+    const abort = new AbortController()
+    const changeStarted = new Deferred<void>()
+    const changeFinished = new Deferred<void>()
+    const call = vi.spyOn(client, 'call')
+
+    client.respondWith('auth.exportLoginToken', () => ({
+      _: 'auth.loginTokenMigrateTo',
+      dcId: 2,
+      token: new Uint8Array(),
+    }))
+    vi.spyOn(client, 'changePrimaryDc').mockImplementation(() => {
+      changeStarted.resolve()
+      return changeFinished.promise
+    })
+
+    const reason = new Error('controlled abort')
+    const result = signInQr(client, {
+      abortSignal: abort.signal,
+      onUrlUpdated: () => {},
+    })
+    const rejection = expect(result).rejects.toBe(reason)
+
+    await changeStarted.promise
+    abort.abort(reason)
+    changeFinished.resolve()
+
+    await rejection
+    expect(call).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/core/src/highlevel/methods/auth/sign-in-qr.ts
+++ b/packages/core/src/highlevel/methods/auth/sign-in-qr.ts
@@ -138,7 +138,11 @@ export async function signInQr(
           ])
           break
         case 'auth.loginTokenMigrateTo': {
+          // The export request can settle just before the caller aborts. Do not mutate
+          // the client's primary DC after this sign-in operation has ended.
+          abortSignal?.throwIfAborted()
           await client.changePrimaryDc(res.dcId)
+          abortSignal?.throwIfAborted()
 
           let res2: tl.auth.TypeLoginToken
 


### PR DESCRIPTION
## Summary

- check the QR operation signal immediately before `changePrimaryDc()`
- check it again before continuing to `auth.importLoginToken`
- add contained regression coverage for aborts on both sides of the DC change

## Relationship to #156 and the connection fix

This is a focused follow-up to #156, not a rewording of it.

- #156 proposed broad destroyed-state guards. It was closed because its tests did not model the production failure and the guards did not fix that mechanism.
- #155 fixed the actual production unhandled rejection: the success-only derived promise created by `asyncResettable()`.
- While investigating the lifecycle concern raised on #156, two separate defects were reproduced. This PR fixes the QR-specific one.
- The independent pending-connect cancellation and late-connected-socket cleanup is in https://github.com/teidesu/fuman/pull/9.

Neither this PR nor the fuman PR is presented as the fix for the historical production incident fixed by #155.

## Contained reproduction

The race does not require a request promise to resolve after cancellation. The export RPC can settle first, then cancellation can occur before its `await` continuation runs.

This is the relevant pre-fix reproduction, using the same `StubTelegramClient` and deferred ordering as the committed regression test:

```ts
const client = new StubTelegramClient()
const abort = new AbortController()
const exportCalled = new Deferred<void>()
const exportResponse = new Deferred<tl.auth.RawLoginTokenMigrateTo>()
const changePrimaryDc = vi.spyOn(client, 'changePrimaryDc').mockResolvedValue()
const call = vi.spyOn(client, 'call')

client.respondWith('auth.exportLoginToken', () => {
  exportCalled.resolve()
  return exportResponse.promise
})

const reason = new Error('controlled abort')
const result = signInQr(client, {
  abortSignal: abort.signal,
  onUrlUpdated: () => {},
})

await exportCalled.promise
exportResponse.resolve({
  _: 'auth.loginTokenMigrateTo',
  dcId: 2,
  token: new Uint8Array(),
})
abort.abort(reason)

await expect(result).rejects.toBe(reason)

// Pre-fix behavior: the client-wide mutation and token import were still entered.
expect(changePrimaryDc).toHaveBeenCalledOnce()
expect(call).toHaveBeenCalledTimes(2)
```

I also ran the contained repro against mtcute 0.29.7. It produced:

```json
{
  "changePrimaryDcCalls": 1,
  "callCount": 2,
  "outcome": "controlled abort"
}
```

The second RPC observed the abort, but only after `signInQr()` had called `changePrimaryDc()` and attempted `auth.importLoginToken`.

## Fix behavior

`signInQr()` checks its own operation signal before entering the client-wide DC mutation. If cancellation arrives while the already-started DC change is in progress, a second check prevents the flow from continuing into token import.

The regression tests are committed in `packages/core/src/highlevel/methods/auth/sign-in-qr.test.ts`:

1. resolve export, abort before the awaiting continuation, and verify that `changePrimaryDc()` is not called;
2. abort during an already-started DC change and verify that `auth.importLoginToken` is not called afterward.

## Verification

- `corepack pnpm test packages/core/src` — 709 passed, 2 skipped
- `corepack pnpm exec vitest run packages/core/src/highlevel/methods/auth/sign-in-qr.test.ts` — 2 passed
- `corepack pnpm exec eslint packages/core/src/highlevel/methods/auth/sign-in-qr.ts packages/core/src/highlevel/methods/auth/sign-in-qr.test.ts`
- `corepack pnpm -C packages/core gen-tl` followed by `corepack pnpm -C packages/core exec tsc --noEmit`
- `git diff --check`

CI test and lint jobs pass on Node 20/22/24, Bun, Deno, and Web.
