### PR TITLE
fix(core): recover synchronous MTProto flush failures

### DIFF
--- a/packages/core/src/network/persistent-connection.ts
+++ b/packages/core/src/network/persistent-connection.ts
@@ -34,6 +34,8 @@ export abstract class PersistentConnection {
   readonly params: PersistentConnectionParams
 
   private _sendOnceConnected: Uint8Array[] = []
+  // Prevent an older async write from restoring ciphertext after its session was discarded.
+  private _sendGeneration = 0
   private _codec: IPacketCodec
   private _fuman: FumanPersistentConnection<BasicDcOption, ITelegramConnection>
 
@@ -144,12 +146,16 @@ export abstract class PersistentConnection {
     this._writer = new FramedWriter(conn, this._codec)
 
     while (this._sendOnceConnected.length) {
+      const generation = this._sendGeneration
       const data = this._sendOnceConnected.shift()!
 
       try {
         await this._writer.write(data)
       } catch (e) {
-        this._sendOnceConnected.unshift(data)
+        // A session reset may have invalidated this write while it was awaiting the transport.
+        if (generation === this._sendGeneration) {
+          this._sendOnceConnected.unshift(data)
+        }
         throw e
       }
     }
@@ -268,7 +274,17 @@ export abstract class PersistentConnection {
     }
   }
 
+  protected _discardPendingSends(): void {
+    // Invalidate buffered writes and writes that may settle after this synchronous reset.
+    // Clearing the writer also makes new payloads wait for the replacement connection.
+    this._sendGeneration += 1
+    this._sendOnceConnected.length = 0
+    this._writer = undefined
+  }
+
   async send(data: Uint8Array): Promise<void> {
+    const generation = this._sendGeneration
+
     if (this._inactive) {
       this.connect()
     }
@@ -278,6 +294,9 @@ export abstract class PersistentConnection {
       try {
         await this._writer.write(data)
       } catch (e: unknown) {
+        // Recovery already reconnects; a late failure from the old session must not reconnect or requeue again.
+        if (generation !== this._sendGeneration) return
+
         if (!(e instanceof ConnectionClosedError)) {
           this.log.warn('encountered an error while sending, reconnecting: %e', e)
           this._writer = undefined
@@ -285,7 +304,7 @@ export abstract class PersistentConnection {
           this._sendOnceConnected.push(data)
         }
       }
-    } else {
+    } else if (generation === this._sendGeneration) {
       this._sendOnceConnected.push(data)
     }
   }

--- a/packages/core/src/network/session-connection.test.ts
+++ b/packages/core/src/network/session-connection.test.ts
@@ -1,0 +1,178 @@
+import type { mtp } from '../tl/index.js'
+import type { PendingRpc } from './mtproto-session.js'
+
+import { Deferred } from '@fuman/utils'
+import { defaultCryptoProvider, defaultPlatform, StubTelegramTransport } from '@mtcute/test'
+import Long from 'long'
+import { describe, expect, it, vi } from 'vitest'
+
+import { __tlReaderMap, __tlWriterMap, LogManager } from '../utils/index.js'
+import { ServerSaltManager } from './server-salt.js'
+import { SessionConnection } from './session-connection.js'
+
+interface SessionConnectionInternals {
+  _active: boolean
+  _activeFlushRpcs: PendingRpc[] | null
+  _flush: () => void
+  _fuman: { reconnect: (force: boolean) => void }
+  _inactivityPendingFlush: boolean
+  _sendOnceConnected: Uint8Array[]
+  _writer?: { write: (data: Uint8Array) => Promise<void> }
+}
+
+function createConnection() {
+  const connection = new SessionConnection(
+    {
+      crypto: defaultCryptoProvider,
+      transport: new StubTelegramTransport({}),
+      dc: {
+        id: 2,
+        ipAddress: '127.0.0.1',
+        port: 443,
+      },
+      testMode: false,
+      reconnectionStrategy: () => false,
+      initConnection: {
+        _: 'initConnection',
+        apiId: 0,
+        deviceModel: '',
+        systemVersion: '',
+        appVersion: '',
+        systemLangCode: '',
+        langPack: '',
+        langCode: '',
+        query: { _: 'help.getNearestDc' },
+      },
+      pingInterval: 60_000,
+      layer: 1,
+      disableUpdates: true,
+      withUpdates: false,
+      isMainConnection: true,
+      isMainDcConnection: true,
+      usePfs: false,
+      salts: new ServerSaltManager(),
+      readerMap: __tlReaderMap,
+      writerMap: __tlWriterMap,
+      platform: defaultPlatform,
+    },
+    new LogManager(undefined, defaultPlatform),
+  )
+  const internals = connection as unknown as SessionConnectionInternals
+
+  connection._session._authKey.ready = true
+  connection._inactive = false
+  internals._active = true
+  connection._session.lastActivityTime = performance.now()
+  connection._session.lastPingTime = performance.now()
+
+  return { connection, internals }
+}
+
+function createRpc(): PendingRpc {
+  return {
+    method: 'help.getNearestDc',
+    data: new Uint8Array([1, 2, 3, 4]),
+    promise: new Deferred<unknown>(),
+  }
+}
+
+describe('SessionConnection flush', () => {
+  it('settles a synchronous flush failure without resending its session payload', async () => {
+    const { connection, internals } = createConnection()
+    const fumanReconnect = vi.fn()
+    internals._fuman = { reconnect: fumanReconnect }
+
+    await connection.send(new Uint8Array([1, 2, 3]))
+    expect(internals._sendOnceConnected).toHaveLength(1)
+
+    const pendingWrite = new Deferred<void>()
+    const write = vi.fn(() => pendingWrite.promise)
+    internals._writer = { write }
+    const inFlightSend = connection.send(new Uint8Array([4, 5, 6]))
+    expect(write).toHaveBeenCalledOnce()
+
+    const rpc = createRpc()
+    const resetAbortSignal = vi.fn()
+    rpc.resetAbortSignal = resetAbortSignal
+    const rejectRpc = vi.spyOn(rpc.promise, 'reject')
+    connection._session.enqueueRpc(rpc, true)
+
+    const bind = new Deferred<boolean | mtp.RawMt_rpc_error>()
+    const rejectBind = vi.spyOn(bind, 'reject')
+    connection._session.pendingMessages.set(Long.ONE, { _: 'bind', promise: bind })
+
+    const rpcRejection = expect(rpc.promise.promise).rejects.toThrow('MTProto flush failed')
+    const bindRejection = expect(bind.promise).rejects.toThrow('MTProto flush failed')
+    const cause = new WebAssembly.RuntimeError('controlled encryption failure')
+    const encrypt = vi.spyOn(connection._session, 'encryptMessage').mockImplementation(() => {
+      internals._flush()
+      throw cause
+    })
+    const resetConnection = vi.spyOn(connection, 'reset')
+    const resetSession = vi.spyOn(connection._session, 'reset')
+    const reconnect = vi.spyOn(connection, 'reconnect').mockImplementation(() => {})
+    const onError = vi.fn()
+    connection.onError.add(onError)
+    const logError = vi.spyOn(connection.log, 'error').mockImplementation(() => {})
+    internals._inactivityPendingFlush = true
+
+    internals._flush()
+    await Promise.all([rpcRejection, bindRejection])
+
+    pendingWrite.reject(new Error('late write failure'))
+    await inFlightSend
+
+    expect(encrypt).toHaveBeenCalledOnce()
+    expect(rejectRpc).toHaveBeenCalledOnce()
+    expect(rejectBind).toHaveBeenCalledOnce()
+    expect(rejectRpc.mock.calls[0][0]).toMatchObject({ message: 'MTProto flush failed' })
+    expect(rejectBind.mock.calls[0][0]).toBe(rejectRpc.mock.calls[0][0])
+    expect(resetAbortSignal).toHaveBeenCalledOnce()
+    expect(rpc.done).toBe(true)
+    expect(connection._session.queuedRpc).toHaveLength(0)
+    expect(connection._session.pendingMessages.size).toBe(0)
+    expect(internals._activeFlushRpcs).toBeNull()
+    expect(internals._sendOnceConnected).toHaveLength(0)
+    expect(internals._writer).toBeUndefined()
+    expect(internals._inactivityPendingFlush).toBe(false)
+    expect(resetConnection).toHaveBeenCalledOnce()
+    expect(resetSession).toHaveBeenCalledOnce()
+    expect(reconnect).toHaveBeenCalledOnce()
+    expect(resetConnection.mock.invocationCallOrder[0]).toBeLessThan(resetSession.mock.invocationCallOrder[0])
+    expect(resetSession.mock.invocationCallOrder[0]).toBeLessThan(reconnect.mock.invocationCallOrder[0])
+    expect(fumanReconnect).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith(cause)
+    expect(logError).toHaveBeenCalledOnce()
+    expect(logError).toHaveBeenCalledWith('flush error')
+  })
+
+  it('clears active RPC tracking after successful and empty flushes', () => {
+    const { connection, internals } = createConnection()
+    const rpc = createRpc()
+    connection._session.enqueueRpc(rpc, true)
+
+    vi.spyOn(connection, 'send').mockResolvedValue()
+    vi.spyOn(connection._session, 'encryptMessage').mockImplementation(() => {
+      expect(internals._activeFlushRpcs).toEqual([rpc])
+      return new Uint8Array([1, 2, 3])
+    })
+
+    internals._flush()
+    expect(internals._activeFlushRpcs).toBeNull()
+
+    connection._session.pendingMessages.clear()
+    connection._session.getStateSchedule.clear()
+    let activeDuringEmptyFlush: PendingRpc[] | null = null
+    vi.spyOn(connection.log, 'debug').mockImplementation((message) => {
+      if (message === 'flushing send queue. queued rpc: %d') {
+        activeDuringEmptyFlush = internals._activeFlushRpcs
+      }
+    })
+
+    internals._flush()
+
+    expect(activeDuringEmptyFlush).toEqual([])
+    expect(internals._activeFlushRpcs).toBeNull()
+    connection.reset()
+  })
+})

--- a/packages/core/src/network/session-connection.ts
+++ b/packages/core/src/network/session-connection.ts
@@ -71,6 +71,8 @@ export class SessionConnection extends PersistentConnection {
 
   private _flushTimer = new EarlyTimer()
   private _queuedDestroySession: Long[] = []
+  // A reentrant flush must not replace the list owned by the flush already in progress.
+  private _activeFlushRpcs: PendingRpc[] | null = null
 
   private _needDestroyAuthKey = false
   private _sentDestroyAuthKey = false
@@ -1743,6 +1745,12 @@ export class SessionConnection extends PersistentConnection {
   }
 
   private _flush(): void {
+    if (this._activeFlushRpcs !== null) {
+      this.log.debug('skipping flush, another flush is already active')
+
+      return
+    }
+
     if (
       this._disconnectedManually
       || !this._session._authKey.ready
@@ -1769,14 +1777,20 @@ export class SessionConnection extends PersistentConnection {
 
     if (this._checkTimeouts(now)) return
 
+    // The caller owns this array until the synchronous flush either completes or is recovered.
+    const activeFlushRpcs: PendingRpc[] = []
+    this._activeFlushRpcs = activeFlushRpcs
+
     try {
-      this._doFlush()
-    } catch (e: any) {
-      this.log.error('flush error: %s', (e as Error).stack)
-      // should not happen unless there's a bug in the code. play safe and reset state
-      this._resetSession('flush error')
+      this._doFlush(activeFlushRpcs)
+    } catch (cause: unknown) {
+      this._recoverFromFlushError(activeFlushRpcs, cause)
 
       return
+    } finally {
+      if (this._activeFlushRpcs === activeFlushRpcs) {
+        this._activeFlushRpcs = null
+      }
     }
 
     // schedule next flush
@@ -1800,7 +1814,39 @@ export class SessionConnection extends PersistentConnection {
     }
   }
 
-  private _doFlush(): void {
+  private _recoverFromFlushError(activeFlushRpcs: PendingRpc[], cause: unknown): void {
+    this.log.error('flush error')
+
+    const error = new MtcuteError('MTProto flush failed')
+    this._activeFlushRpcs = null
+
+    for (const rpc of activeFlushRpcs) {
+      rpc.done = true
+      if (rpc.timeout) {
+        timers.clearTimeout(rpc.timeout)
+        rpc.timeout = undefined
+      }
+      rpc.resetAbortSignal?.()
+      rpc.resetAbortSignal = undefined
+      if (rpc.msgId) this._session.pendingMessages.delete(rpc.msgId)
+      rpc.promise.reject(error)
+    }
+
+    // MtprotoSession.reset() only rejects RPC entries; an abandoned bind would block PFS progress.
+    for (const pending of this._session.pendingMessages.values()) {
+      if (pending._ === 'bind') pending.promise.reject(error)
+    }
+
+    this._discardPendingSends()
+    this._inactivityPendingFlush = false
+    // Do not use _resetSession(): its recovery contract requeues pending RPCs for resend.
+    this.reset()
+    this._session.reset()
+    this.reconnect()
+    this.onError.emit(cause instanceof Error ? cause : error)
+  }
+
+  private _doFlush(rpcToSend: PendingRpc[]): void {
     this.log.debug('flushing send queue. queued rpc: %d', this._session.queuedRpc.length)
 
     // oh bloody hell mate
@@ -1960,7 +2006,6 @@ export class SessionConnection extends PersistentConnection {
     }
 
     let forceContainer = false
-    const rpcToSend: PendingRpc[] = []
 
     while (
       this._session.queuedRpc.length


### PR DESCRIPTION
## Summary

- track every RPC removed from the send queue by an active synchronous flush
- on serialization or encryption failure, terminally reject those RPCs and pending PFS bind waiters, discard buffered and late-restored ciphertext, reset connection/session state without requeueing the broken payload, and reconnect once
- guard reentrant flushes and clear active tracking after successful and empty flushes

## Root cause

A synchronous flush can remove RPCs from `queuedRpc` before registering them in `pendingMessages`. If a later synchronous step such as encryption throws, the ordinary reset path cannot account for those RPCs and may either strand their promises or requeue partially registered work. Ciphertext already waiting for the next connection, including data restored by a late asynchronous write failure, can also survive the session reset.

## Tests

- `corepack pnpm test packages/core/src/network/session-connection.test.ts packages/core/src/network/network-manager.test.ts` (8 tests passed)
- `corepack pnpm exec eslint packages/core/src/network/session-connection.ts packages/core/src/network/persistent-connection.ts packages/core/src/network/session-connection.test.ts`
- `corepack pnpm exec tsc -p packages/core/tsconfig.json`
- `git diff --check`