### PR TITLE
fix: start todo item ids at 1 to avoid TODO_ITEM_DUPLICATE

### DIFF
--- a/packages/core/src/highlevel/methods/files/normalize-input-media.ts
+++ b/packages/core/src/highlevel/methods/files/normalize-input-media.ts
@@ -268,7 +268,7 @@ export async function _normalizeInputMedia(
         title: inputTextToTl(media.title),
         list: media.items.map((it, idx) => ({
           _: 'todoItem',
-          id: idx,
+          id: idx + 1,
           title: inputTextToTl(it),
         })),
       },


### PR DESCRIPTION
# Summary
tg requires todo item ids to be positive and non-zero.
`InputMedia.todo` currently assigns `id: idx`, so the first item gets `id: 0`, which causes `TODO_ITEM_DUPLICATE` when sending a checklist via `messages.sendMedia`.
## Change
In `normalize-input-media.ts`, change:
```ts
id: idx,
```
to 
```ts
id: idx + 1
```