### PR TITLE
fix(core): abort requests after a flush exception

### DIFF
--- a/packages/core/src/network/authorization.ts
+++ b/packages/core/src/network/authorization.ts
@@ -187,13 +187,15 @@ export async function doAuthorization(
   connection: SessionConnection,
   crypto: ICryptoProvider,
   expiresIn?: number,
+  abortSignal?: AbortSignal,
 ): Promise<[Uint8Array, Long, number]> {
   const session = connection['_session']
   const readerMap = session._readerMap
   const writerMap = session._writerMap
   const log = connection.log.create('auth')
 
-  function sendPlainMessage(message: mtp.TlObject): Promise<void> {
+  async function sendPlainMessage(message: mtp.TlObject): Promise<void> {
+    abortSignal?.throwIfAborted()
     const length = TlSerializationCounter.countNeededBytes(writerMap, message)
     const writer = TlBinaryWriter.alloc(writerMap, length + 20) // 20 bytes for mtproto header
 
@@ -205,13 +207,18 @@ export async function doAuthorization(
     writer.uint(length)
     writer.object(message)
 
-    return connection.send(writer.result())
+    abortSignal?.throwIfAborted()
+    await connection.send(writer.result())
+    abortSignal?.throwIfAborted()
   }
 
   async function readNext(): Promise<mtp.TlObject> {
+    abortSignal?.throwIfAborted()
+    const message = await connection.waitForUnencryptedMessage(undefined, abortSignal)
+    abortSignal?.throwIfAborted()
     const res = TlBinaryReader.deserializeObject<mtp.TlObject>(
       readerMap,
-      await connection.waitForUnencryptedMessage(),
+      message,
       20, // skip mtproto header
     )
 
@@ -220,6 +227,7 @@ export async function doAuthorization(
     return res
   }
 
+  abortSignal?.throwIfAborted()
   if (expiresIn) log.prefix = '[PFS] '
 
   const nonce = crypto.randomBytes(16)
@@ -253,6 +261,7 @@ export async function doAuthorization(
   }
 
   const [p, q] = await crypto.factorizePQ(resPq.pq)
+  abortSignal?.throwIfAborted()
   log.debug('factorized PQ: PQ = %h, P = %h, Q = %h', resPq.pq, p, q)
 
   const newNonce = crypto.randomBytes(32)

--- a/packages/core/src/network/mtproto-session.ts
+++ b/packages/core/src/network/mtproto-session.ts
@@ -1,4 +1,4 @@
-import type { Deferred, timers } from '@fuman/utils'
+import type { Deferred } from '@fuman/utils'
 import type { TlBinaryWriter, TlReaderMap, TlWriterMap } from '@mtcute/tl-runtime'
 import type { mtp, tl } from '../tl/index.js'
 import type {
@@ -6,7 +6,7 @@ import type {
   Logger,
 } from '../utils/index.js'
 import type { ServerSaltManager } from './server-salt.js'
-import { Deque, LruMap, LruSet } from '@fuman/utils'
+import { Deque, LruMap, LruSet, timers } from '@fuman/utils'
 
 import { TlSerializationCounter } from '@mtcute/tl-runtime'
 import Long from 'long'
@@ -217,29 +217,47 @@ export class MtprotoSession {
     // reset session state
 
     if (!keepPending) {
+      const error = new MtcuteError('Session is reset')
+      const rejectedRpcs = new Set<PendingRpc>()
+      const rejectRpc = (rpc: PendingRpc) => {
+        if (rejectedRpcs.has(rpc)) return
+        rejectedRpcs.add(rpc)
+
+        rpc.done = true
+        if (rpc.timeout) {
+          timers.clearTimeout(rpc.timeout)
+          rpc.timeout = undefined
+        }
+        rpc.resetAbortSignal?.()
+        rpc.resetAbortSignal = undefined
+        if (rpc.cancelled) return
+
+        this.log.debug('rejecting pending rpc %s', rpc.method)
+        rpc.promise.reject(error)
+      }
+
       for (const info of this.pendingMessages.values()) {
         if (info._ === 'rpc') {
-          this.log.debug('rejecting pending rpc %s', info.rpc.method)
-          info.rpc.promise.reject(new MtcuteError('Session is reset'))
+          rejectRpc(info.rpc)
+        } else if (info._ === 'bind') {
+          info.promise.reject(error)
         }
       }
       this.pendingMessages.clear()
+
+      while (this.queuedRpc.length) {
+        rejectRpc(this.queuedRpc.popFront()!)
+      }
+
+      for (const timeout of this.pendingGetStateTimeouts.values()) {
+        timers.clearTimeout(timeout)
+      }
+      this.pendingGetStateTimeouts.clear()
     }
 
     this.recentOutgoingMsgIds.clear()
     this.recentIncomingMsgIds.clear()
     this.recentStateRequests.clear()
-
-    if (!keepPending) {
-      while (this.queuedRpc.length) {
-        const rpc = this.queuedRpc.popFront()!
-
-        if (rpc.sent === false) {
-          this.log.debug('rejecting pending rpc %s', rpc.method)
-          rpc.promise.reject(new MtcuteError('Session is reset'))
-        }
-      }
-    }
 
     this.queuedAcks.length = 0
     this.queuedStateReq.length = 0

--- a/packages/core/src/network/session-connection.test.ts
+++ b/packages/core/src/network/session-connection.test.ts
@@ -1,32 +1,202 @@
+import type { PendingRpc } from './mtproto-session.js'
 import type { SessionConnection } from './session-connection.js'
 import { Deferred } from '@fuman/utils'
 import { StubTelegramClient } from '@mtcute/test'
+import { TlBinaryWriter } from '@mtcute/tl-runtime'
 import Long from 'long'
 import { describe, expect, it, vi } from 'vitest'
+
+interface TestConnection {
+  _active: boolean
+  _cancelRpc(rpc: PendingRpc, onTimeout?: boolean, abortSignal?: AbortSignal): void
+  _flush(): void
+  _onPong(message: { _: 'mt_pong', msgId: Long, pingId: Long }): void
+  _session: SessionConnection['_session']
+  log: SessionConnection['log']
+  reconnect: SessionConnection['reconnect']
+  reset: SessionConnection['reset']
+  send: SessionConnection['send']
+}
 
 async function createConnection() {
   const client = new StubTelegramClient()
   await client.connect()
 
-  const conn = client.mt.network._primaryDc!.main._connections[0] as SessionConnection & Record<string, any>
+  const conn = client.mt.network._primaryDc!.main._connections[0] as unknown as TestConnection
 
   return { client, conn }
 }
 
-function sendPing(conn: SessionConnection & Record<string, any>) {
+function createRpc(method: string): PendingRpc {
+  return {
+    method,
+    promise: new Deferred<unknown>(),
+    data: new Uint8Array([1, 2, 3, 4]),
+  }
+}
+
+function prepareFlush(conn: TestConnection, rpcs: PendingRpc[]) {
+  conn._active = true
+  conn._session.lastActivityTime = performance.now()
+  conn._session.lastPingTime = performance.now()
+  rpcs.forEach(rpc => conn._session.enqueueRpc(rpc, true))
+}
+
+async function expectRpcsCanRetry(conn: TestConnection, rpcs: PendingRpc[]) {
+  vi.spyOn(conn._session, 'encryptMessage').mockReturnValue(new Uint8Array([1, 2, 3]))
+  vi.spyOn(conn, 'send').mockResolvedValue()
+
+  conn._flush()
+
+  for (const rpc of rpcs) {
+    expect(rpc.msgId).toBeDefined()
+    expect(conn._session.pendingMessages.get(rpc.msgId!)).toEqual({ _: 'rpc', rpc })
+  }
+
+  const containerId = rpcs[0].containerId!
+  expect(rpcs.every(rpc => rpc.containerId?.eq(containerId))).toBe(true)
+  const container = conn._session.pendingMessages.get(containerId)
+  expect(container?._).toBe('container')
+  if (container?._ === 'container') {
+    const rpcMsgIds = container.msgIds.filter(msgId => rpcs.some(rpc => rpc.msgId!.eq(msgId)))
+    expect(rpcMsgIds).toHaveLength(rpcs.length)
+  }
+
+  const rejections = rpcs.map(rpc => expect(rpc.promise.promise).rejects.toThrow('Session is reset'))
+  conn._session.resetState()
+  await Promise.all(rejections)
+}
+
+function sendPing(conn: TestConnection) {
   conn._session.lastPingTime = performance.now() - 1_000_000
-  conn['_flush']()
+  conn._flush()
 
   const msgId = conn._session.lastPingMsgId
   expect(msgId.isZero()).toBe(false)
+  const pending = conn._session.pendingMessages.get(msgId)
+  if (pending?._ !== 'ping') throw new Error('Expected pending ping')
 
   return {
     msgId,
-    pingId: (conn._session.pendingMessages.get(msgId)! as any).pingId as Long,
+    pingId: pending.pingId,
   }
 }
 
 describe('SessionConnection', () => {
+  describe('flush failure recovery', () => {
+    it('should retain fresh and resent RPCs when packet allocation fails before registration', async () => {
+      const { client, conn } = await createConnection()
+      const rpcs = [createRpc('rpc.one'), createRpc('rpc.two'), createRpc('rpc.three')]
+
+      rpcs[0].msgId = Long.fromNumber(4)
+      rpcs[0].seqNo = 1
+      conn._session.pendingMessages.set(rpcs[0].msgId, { _: 'rpc', rpc: rpcs[0] })
+      prepareFlush(conn, rpcs)
+
+      vi.spyOn(conn, 'reconnect').mockImplementation(() => {})
+      vi.spyOn(conn.log, 'error').mockImplementation(() => {})
+      const setPending = vi.spyOn(conn._session.pendingMessages, 'set')
+      let queuedAtAllocation = -1
+      const allocatePacket = vi.spyOn(TlBinaryWriter, 'alloc').mockImplementation(() => {
+        queuedAtAllocation = conn._session.queuedRpc.length
+        throw new Error('injected packet construction failure')
+      })
+
+      conn._flush()
+
+      const allocationCalls = allocatePacket.mock.calls.length
+      const registrationCalls = setPending.mock.calls.length
+      allocatePacket.mockRestore()
+      setPending.mockRestore()
+
+      expect(allocationCalls).toBe(1)
+      expect(registrationCalls).toBe(0)
+      expect(queuedAtAllocation).toBe(0)
+      expect(conn._session.pendingMessages.size).toBe(0)
+      expect(conn._session.queuedRpc.toArray()).toEqual(rpcs)
+      rpcs.forEach((rpc) => {
+        expect(rpc.msgId).toBeUndefined()
+        expect(rpc.sent).toBe(false)
+        expect(rpc.containerId).toBeUndefined()
+      })
+
+      await expectRpcsCanRetry(conn, rpcs)
+      await client.destroy()
+    })
+
+    it('should retain every RPC when packet construction partially registers a batch', async () => {
+      const { client, conn } = await createConnection()
+      const rpcs = [createRpc('rpc.one'), createRpc('rpc.two'), createRpc('rpc.three')]
+      rpcs.forEach((rpc) => {
+        rpc.chainId = 'ordered'
+      })
+      prepareFlush(conn, rpcs)
+
+      vi.spyOn(conn, 'reconnect').mockImplementation(() => {})
+      vi.spyOn(conn.log, 'error').mockImplementation(() => {})
+      const originalSetPending = conn._session.pendingMessages.set.bind(conn._session.pendingMessages)
+      let registeredRpcs = 0
+      const setPending = vi.spyOn(conn._session.pendingMessages, 'set').mockImplementation((msgId, pending) => {
+        if (pending._ === 'rpc' && ++registeredRpcs === 2) {
+          throw new Error('injected packet construction failure')
+        }
+
+        return originalSetPending(msgId, pending)
+      })
+
+      conn._flush()
+
+      const registrationCalls = setPending.mock.calls.length
+      setPending.mockRestore()
+
+      expect(registrationCalls).toBe(2)
+      expect(conn._session.pendingMessages.size).toBe(0)
+      // Session reset appends registered RPCs, so exact order matters for chainId retries.
+      expect(conn._session.queuedRpc.toArray()).toEqual(rpcs)
+
+      await expectRpcsCanRetry(conn, rpcs)
+      expect(rpcs[0].invokeAfter).toBeUndefined()
+      expect(rpcs[1].invokeAfter?.eq(rpcs[0].msgId!)).toBe(true)
+      expect(rpcs[2].invokeAfter?.eq(rpcs[1].msgId!)).toBe(true)
+      await client.destroy()
+    })
+
+    it('should not restore an RPC that times out before its pending registration', async () => {
+      const { client, conn } = await createConnection()
+      const rpcs = [createRpc('rpc.one'), createRpc('rpc.two'), createRpc('rpc.three')]
+      prepareFlush(conn, rpcs)
+
+      vi.spyOn(conn, 'reconnect').mockImplementation(() => {})
+      vi.spyOn(conn.log, 'error').mockImplementation(() => {})
+      const originalSetPending = conn._session.pendingMessages.set.bind(conn._session.pendingMessages)
+      let registeredRpcs = 0
+      const setPending = vi.spyOn(conn._session.pendingMessages, 'set').mockImplementation((msgId, pending) => {
+        if (pending._ === 'rpc' && ++registeredRpcs === 2) {
+          conn._cancelRpc(pending.rpc, true)
+          throw new Error('injected packet construction failure')
+        }
+
+        return originalSetPending(msgId, pending)
+      })
+      const timeoutSettlement = expect(rpcs[1].promise.promise).resolves.toMatchObject({
+        _: 'mt_rpc_error',
+        errorMessage: 'TIMEOUT',
+      })
+
+      conn._flush()
+      setPending.mockRestore()
+
+      const retainedRpcs = [rpcs[0], rpcs[2]]
+      expect(conn._session.pendingMessages.size).toBe(0)
+      expect(conn._session.queuedRpc.toArray()).toEqual(retainedRpcs)
+      expect(rpcs[1].cancelled).toBe(true)
+
+      await expectRpcsCanRetry(conn, retainedRpcs)
+      await timeoutSettlement
+      await client.destroy()
+    })
+  })
+
   describe('ping handling', () => {
     it('should handle pong to a ping that was sent before the connection became active', async () => {
       const { client, conn } = await createConnection()
@@ -40,14 +210,14 @@ describe('SessionConnection', () => {
         rpc: { method: 'help.getConfig', promise: def, data: new Uint8Array() },
       })
       conn._session.lastPingTime = performance.now() - 1_000_000
-      conn['_flush']()
+      conn._flush()
 
       const activePing = { msgId: conn._session.lastPingMsgId }
       expect(activePing.msgId.eq(idlePing.msgId)).toBe(false)
       expect(conn._session.pendingMessages.has(idlePing.msgId)).toBe(true)
 
       const warn = vi.spyOn(conn.log, 'warn')
-      conn['_onPong']({ _: 'mt_pong', msgId: idlePing.msgId, pingId: idlePing.pingId })
+      conn._onPong({ _: 'mt_pong', msgId: idlePing.msgId, pingId: idlePing.pingId })
 
       expect(warn).not.toHaveBeenCalled()
       expect(conn._session.pendingMessages.has(idlePing.msgId)).toBe(false)

--- a/packages/core/src/network/session-connection.test.ts
+++ b/packages/core/src/network/session-connection.test.ts
@@ -1,6 +1,8 @@
+import type { mtp } from '../tl/index.js'
 import type { PendingRpc } from './mtproto-session.js'
+import type { ServerSaltManager } from './server-salt.js'
 import type { SessionConnection } from './session-connection.js'
-import { Deferred } from '@fuman/utils'
+import { Deferred, timers } from '@fuman/utils'
 import { StubTelegramClient } from '@mtcute/test'
 import { TlBinaryWriter } from '@mtcute/tl-runtime'
 import Long from 'long'
@@ -10,16 +12,36 @@ interface TestConnection {
   _active: boolean
   _cancelRpc(rpc: PendingRpc, onTimeout?: boolean, abortSignal?: AbortSignal): void
   _flush(): void
+  _inactive: boolean
+  _inactivityPendingFlush: boolean
+  _isPfsBindingPending: boolean
+  _isPfsBindingPendingInBackground: boolean
+  _needDestroyAuthKey: boolean
   _onPong(message: { _: 'mt_pong', msgId: Long, pingId: Long }): void
+  _pendingWaitForUnencrypted: unknown[]
+  _pfsAuthorizationAbort?: AbortController
+  _queuedDestroySession: Long[]
+  _salts: ServerSaltManager
+  _sentDestroyAuthKey: boolean
   _session: SessionConnection['_session']
   log: SessionConnection['log']
+  onUpdate: SessionConnection['onUpdate']
+  params: SessionConnection['params']
   reconnect: SessionConnection['reconnect']
   reset: SessionConnection['reset']
+  setUsePfs: SessionConnection['setUsePfs']
   send: SessionConnection['send']
+  sendRpc: SessionConnection['sendRpc']
+  waitForUnencryptedMessage(timeout?: number, abortSignal?: AbortSignal): Promise<Uint8Array>
 }
 
-async function createConnection() {
-  const client = new StubTelegramClient()
+interface SessionConnectionInternals {
+  _doFlush(context: { rpcToSend: PendingRpc[], ownsDestroyAuthKeySend: boolean }): void
+  _onNewSessionCreated(message: mtp.RawMt_new_session_created): void
+}
+
+async function createConnection(usePfs = false) {
+  const client = new StubTelegramClient(usePfs ? { network: { usePfs: true } } : undefined)
   await client.connect()
 
   const conn = client.mt.network._primaryDc!.main._connections[0] as unknown as TestConnection
@@ -42,29 +64,8 @@ function prepareFlush(conn: TestConnection, rpcs: PendingRpc[]) {
   rpcs.forEach(rpc => conn._session.enqueueRpc(rpc, true))
 }
 
-async function expectRpcsCanRetry(conn: TestConnection, rpcs: PendingRpc[]) {
-  vi.spyOn(conn._session, 'encryptMessage').mockReturnValue(new Uint8Array([1, 2, 3]))
-  vi.spyOn(conn, 'send').mockResolvedValue()
-
-  conn._flush()
-
-  for (const rpc of rpcs) {
-    expect(rpc.msgId).toBeDefined()
-    expect(conn._session.pendingMessages.get(rpc.msgId!)).toEqual({ _: 'rpc', rpc })
-  }
-
-  const containerId = rpcs[0].containerId!
-  expect(rpcs.every(rpc => rpc.containerId?.eq(containerId))).toBe(true)
-  const container = conn._session.pendingMessages.get(containerId)
-  expect(container?._).toBe('container')
-  if (container?._ === 'container') {
-    const rpcMsgIds = container.msgIds.filter(msgId => rpcs.some(rpc => rpc.msgId!.eq(msgId)))
-    expect(rpcMsgIds).toHaveLength(rpcs.length)
-  }
-
-  const rejections = rpcs.map(rpc => expect(rpc.promise.promise).rejects.toThrow('Session is reset'))
-  conn._session.resetState()
-  await Promise.all(rejections)
+function expectRpcsRejected(rpcs: PendingRpc[]) {
+  return Promise.all(rpcs.map(rpc => expect(rpc.promise.promise).rejects.toThrow('Session is reset')))
 }
 
 function sendPing(conn: TestConnection) {
@@ -83,8 +84,8 @@ function sendPing(conn: TestConnection) {
 }
 
 describe('SessionConnection', () => {
-  describe('flush failure recovery', () => {
-    it('should retain fresh and resent RPCs when packet allocation fails before registration', async () => {
+  describe('flush failure handling', () => {
+    it('should settle fresh and resent RPCs when packet allocation fails before registration', async () => {
       const { client, conn } = await createConnection()
       const rpcs = [createRpc('rpc.one'), createRpc('rpc.two'), createRpc('rpc.three')]
 
@@ -102,7 +103,9 @@ describe('SessionConnection', () => {
         throw new Error('injected packet construction failure')
       })
 
+      const rejections = expectRpcsRejected(rpcs)
       conn._flush()
+      await rejections
 
       const allocationCalls = allocatePacket.mock.calls.length
       const registrationCalls = setPending.mock.calls.length
@@ -113,18 +116,13 @@ describe('SessionConnection', () => {
       expect(registrationCalls).toBe(0)
       expect(queuedAtAllocation).toBe(0)
       expect(conn._session.pendingMessages.size).toBe(0)
-      expect(conn._session.queuedRpc.toArray()).toEqual(rpcs)
-      rpcs.forEach((rpc) => {
-        expect(rpc.msgId).toBeUndefined()
-        expect(rpc.sent).toBe(false)
-        expect(rpc.containerId).toBeUndefined()
-      })
-
-      await expectRpcsCanRetry(conn, rpcs)
+      expect(conn._session.queuedRpc).toHaveLength(0)
+      expect(rpcs.every(rpc => rpc.done)).toBe(true)
+      expect(conn.reconnect).not.toHaveBeenCalled()
       await client.destroy()
     })
 
-    it('should retain every RPC when packet construction partially registers a batch', async () => {
+    it('should settle every RPC once when packet construction partially registers a batch', async () => {
       const { client, conn } = await createConnection()
       const rpcs = [createRpc('rpc.one'), createRpc('rpc.two'), createRpc('rpc.three')]
       rpcs.forEach((rpc) => {
@@ -144,26 +142,27 @@ describe('SessionConnection', () => {
         return originalSetPending(msgId, pending)
       })
 
+      const rejectRpcs = rpcs.map(rpc => vi.spyOn(rpc.promise, 'reject'))
+      const rejections = expectRpcsRejected(rpcs)
       conn._flush()
+      await rejections
 
       const registrationCalls = setPending.mock.calls.length
       setPending.mockRestore()
 
       expect(registrationCalls).toBe(2)
       expect(conn._session.pendingMessages.size).toBe(0)
-      // Session reset appends registered RPCs, so exact order matters for chainId retries.
-      expect(conn._session.queuedRpc.toArray()).toEqual(rpcs)
-
-      await expectRpcsCanRetry(conn, rpcs)
-      expect(rpcs[0].invokeAfter).toBeUndefined()
-      expect(rpcs[1].invokeAfter?.eq(rpcs[0].msgId!)).toBe(true)
-      expect(rpcs[2].invokeAfter?.eq(rpcs[1].msgId!)).toBe(true)
+      expect(conn._session.queuedRpc).toHaveLength(0)
+      expect(rejectRpcs.every(reject => reject.mock.calls.length === 1)).toBe(true)
+      expect(conn.reconnect).not.toHaveBeenCalled()
       await client.destroy()
     })
 
     it('should not restore an RPC that times out before its pending registration', async () => {
       const { client, conn } = await createConnection()
       const rpcs = [createRpc('rpc.one'), createRpc('rpc.two'), createRpc('rpc.three')]
+      const resetAbortSignal = vi.fn()
+      rpcs[1].resetAbortSignal = resetAbortSignal
       prepareFlush(conn, rpcs)
 
       vi.spyOn(conn, 'reconnect').mockImplementation(() => {})
@@ -183,18 +182,262 @@ describe('SessionConnection', () => {
         errorMessage: 'TIMEOUT',
       })
 
+      const terminalSettlement = expectRpcsRejected([rpcs[0], rpcs[2]])
       conn._flush()
       setPending.mockRestore()
+      await Promise.all([timeoutSettlement, terminalSettlement])
 
-      const retainedRpcs = [rpcs[0], rpcs[2]]
       expect(conn._session.pendingMessages.size).toBe(0)
-      expect(conn._session.queuedRpc.toArray()).toEqual(retainedRpcs)
+      expect(conn._session.queuedRpc).toHaveLength(0)
       expect(rpcs[1].cancelled).toBe(true)
-
-      await expectRpcsCanRetry(conn, retainedRpcs)
-      await timeoutSettlement
+      expect(rpcs[1].timeout).toBeUndefined()
+      expect(rpcs[1].resetAbortSignal).toBeUndefined()
+      expect(resetAbortSignal).toHaveBeenCalledOnce()
+      expect(conn.reconnect).not.toHaveBeenCalled()
       await client.destroy()
     })
+
+    it('should emit the exact error once without retrying and allow later work on a new session', async () => {
+      const { client, conn } = await createConnection()
+      const cause = new Error('controlled encryption failure')
+      const onError = vi.fn()
+      client.onError.add(onError)
+
+      const oldSessionId = conn._session._sessionId
+      const originalEncryptMessage = conn._session.encryptMessage.bind(conn._session)
+      let fail = true
+      const encryptMessage = vi.spyOn(conn._session, 'encryptMessage').mockImplementation((message) => {
+        if (fail) throw cause
+        return originalEncryptMessage(message)
+      })
+      vi.spyOn(conn, 'send').mockResolvedValue()
+      const reconnect = vi.spyOn(conn, 'reconnect').mockImplementation(() => {})
+
+      const failedRequest = conn.sendRpc({ _: 'help.getNearestDc' })
+      await expect(failedRequest).rejects.toThrow('Session is reset')
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+
+      expect(encryptMessage).toHaveBeenCalledOnce()
+      expect(onError).toHaveBeenCalledOnce()
+      expect(onError).toHaveBeenCalledWith(cause)
+      expect(reconnect).not.toHaveBeenCalled()
+      expect(conn._session._sessionId.eq(oldSessionId)).toBe(false)
+
+      fail = false
+      const laterRequest = conn.sendRpc({ _: 'help.getNearestDc' })
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+
+      expect(encryptMessage).toHaveBeenCalledTimes(2)
+      expect([...conn._session.pendingMessages.values()].some(info => info._ === 'rpc')).toBe(true)
+      const laterRejection = expect(laterRequest).rejects.toThrow('Session is reset')
+      conn._session.resetState()
+      await laterRejection
+      await client.destroy()
+    })
+
+    it('should normalize a cyclic non-Error value without bypassing settlement', async () => {
+      const { client, conn } = await createConnection()
+      const cause: Record<string, unknown> = {}
+      cause.self = cause
+      const onError = vi.fn()
+      client.onError.add(onError)
+      vi.spyOn(conn._session, 'encryptMessage').mockImplementation(() => {
+        throw cause
+      })
+
+      const request = conn.sendRpc({ _: 'help.getNearestDc' })
+      await expect(request).rejects.toThrow('Session is reset')
+
+      expect(onError).toHaveBeenCalledOnce()
+      const error = onError.mock.calls[0][0]
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message).toBe('Non-Error value thrown')
+      expect((error as Error & { cause: unknown }).cause).toBe(cause)
+      await client.destroy()
+    })
+
+    it('should cancel PFS waiters and clear terminal request hooks', async () => {
+      const { client, conn } = await createConnection()
+      const internals = conn as unknown as SessionConnectionInternals
+      const rpc = createRpc('rpc.with-hooks')
+      const resetAbortSignal = vi.fn()
+      rpc.timeout = timers.setTimeout(() => {}, 60_000)
+      rpc.resetAbortSignal = resetAbortSignal
+      prepareFlush(conn, [rpc])
+
+      const authorizationAbort = new AbortController()
+      conn._pfsAuthorizationAbort = authorizationAbort
+      conn._isPfsBindingPendingInBackground = true
+      const authorizationWaiter = conn.waitForUnencryptedMessage(60_000, authorizationAbort.signal)
+      const bind = new Deferred<boolean | mtp.RawMt_rpc_error>()
+      conn._session.pendingMessages.set(Long.ONE, { _: 'bind', promise: bind })
+      const getStateTimeout = timers.setTimeout(() => {}, 60_000)
+      conn._session.pendingGetStateTimeouts.set(Long.fromNumber(2), getStateTimeout)
+
+      const rpcRejection = expect(rpc.promise.promise).rejects.toThrow('Session is reset')
+      const authorizationRejection = expect(authorizationWaiter).rejects.toThrow('Session is reset')
+      const bindRejection = expect(bind.promise).rejects.toThrow('Session is reset')
+      vi.spyOn(internals, '_doFlush').mockImplementation(() => {
+        throw new Error('controlled packet failure')
+      })
+      const reconnect = vi.spyOn(conn, 'reconnect').mockImplementation(() => {})
+
+      conn._flush()
+      await Promise.all([rpcRejection, authorizationRejection, bindRejection])
+
+      expect(authorizationAbort.signal.aborted).toBe(true)
+      expect(conn._isPfsBindingPending).toBe(false)
+      expect(conn._isPfsBindingPendingInBackground).toBe(false)
+      expect(conn._pendingWaitForUnencrypted).toHaveLength(0)
+      expect(resetAbortSignal).toHaveBeenCalledOnce()
+      expect(rpc.done).toBe(true)
+      expect(rpc.timeout).toBeUndefined()
+      expect(rpc.resetAbortSignal).toBeUndefined()
+      expect(conn._session.pendingGetStateTimeouts.size).toBe(0)
+      expect(reconnect).not.toHaveBeenCalled()
+      await client.destroy()
+    })
+
+    it('should cancel an active PFS attempt when PFS is disabled', async () => {
+      const { client, conn } = await createConnection(true)
+      const authorizationAbort = new AbortController()
+      conn._pfsAuthorizationAbort = authorizationAbort
+      conn._isPfsBindingPendingInBackground = true
+      const authorizationWaiter = conn.waitForUnencryptedMessage(60_000, authorizationAbort.signal)
+      const reconnect = vi.spyOn(conn, 'reconnect').mockImplementation(() => {})
+
+      conn.setUsePfs(false)
+
+      await expect(authorizationWaiter).rejects.toThrow('PFS setting changed')
+      expect(authorizationAbort.signal.aborted).toBe(true)
+      expect(conn._isPfsBindingPending).toBe(false)
+      expect(conn._isPfsBindingPendingInBackground).toBe(false)
+      expect(conn._pendingWaitForUnencrypted).toHaveLength(0)
+      expect(reconnect).toHaveBeenCalledOnce()
+      await client.destroy()
+    })
+
+    it('should cancel an earlier pending inactivity close', async () => {
+      const { client, conn } = await createConnection()
+      const firstSend = new Deferred<void>()
+      const send = vi.spyOn(conn, 'send').mockReturnValueOnce(firstSend.promise)
+      let fail = false
+      vi.spyOn(conn._session, 'encryptMessage').mockImplementation(() => {
+        if (fail) throw new Error('controlled packet failure')
+        return new Uint8Array([1, 2, 3])
+      })
+      vi.spyOn(conn.log, 'error').mockImplementation(() => {})
+
+      conn._session.lastActivityTime = performance.now()
+      conn._session.lastPingTime = performance.now()
+      conn._session.queuedAcks.push(Long.ONE)
+      conn._inactivityPendingFlush = true
+      conn._flush()
+
+      expect(send).toHaveBeenCalledOnce()
+      expect(conn._inactivityPendingFlush).toBe(true)
+
+      fail = true
+      const rpc = createRpc('rpc.after-inactivity-flush')
+      prepareFlush(conn, [rpc])
+      const rejection = expectRpcsRejected([rpc])
+      conn._flush()
+      await rejection
+
+      expect(conn._inactivityPendingFlush).toBe(false)
+      conn._inactivityPendingFlush = true
+      firstSend.resolve()
+      await firstSend.promise
+      await Promise.resolve()
+
+      expect(conn._inactive).toBe(false)
+      expect(conn._inactivityPendingFlush).toBe(true)
+      await client.destroy()
+    })
+
+    it('should roll back only service markers owned by the failed packet', async () => {
+      const { client, conn } = await createConnection()
+      const shouldFetchSalts = vi.spyOn(conn._salts, 'shouldFetchSalts').mockReturnValue(true)
+      let failEncryption = true
+      vi.spyOn(conn._session, 'encryptMessage').mockImplementation(() => {
+        if (failEncryption) throw new Error('controlled service-packet failure')
+        return new Uint8Array([1, 2, 3])
+      })
+      conn._needDestroyAuthKey = true
+      conn._queuedDestroySession.push(Long.fromNumber(123))
+
+      const firstRpc = createRpc('rpc.with-owned-service-state')
+      prepareFlush(conn, [firstRpc])
+      const firstRejection = expectRpcsRejected([firstRpc])
+      conn._flush()
+      await firstRejection
+
+      expect(conn._salts.isFetching).toBe(false)
+      expect(conn._needDestroyAuthKey).toBe(true)
+      expect(conn._sentDestroyAuthKey).toBe(false)
+      expect(conn._queuedDestroySession).toHaveLength(0)
+
+      shouldFetchSalts.mockReturnValue(false)
+      conn._salts.isFetching = true
+      conn._sentDestroyAuthKey = true
+      const secondRpc = createRpc('rpc.with-sibling-salt-state')
+      prepareFlush(conn, [secondRpc])
+      const secondRejection = expectRpcsRejected([secondRpc])
+      conn._flush()
+      await secondRejection
+
+      expect(conn._salts.isFetching).toBe(true)
+      expect(conn._sentDestroyAuthKey).toBe(true)
+
+      failEncryption = false
+      conn._salts.isFetching = false
+      conn._sentDestroyAuthKey = false
+      shouldFetchSalts.mockReturnValue(true)
+      const markersAtSend = vi.spyOn(conn, 'send').mockImplementation(() => {
+        expect(conn._salts.isFetching).toBe(true)
+        expect(conn._sentDestroyAuthKey).toBe(true)
+        throw new Error('controlled send handoff failure')
+      })
+      const sentRpc = createRpc('rpc.with-sent-service-state')
+      prepareFlush(conn, [sentRpc])
+      const sentRpcRejection = expectRpcsRejected([sentRpc])
+      conn._flush()
+      await sentRpcRejection
+
+      expect(markersAtSend).toHaveBeenCalledOnce()
+      expect(conn._salts.isFetching).toBe(false)
+      expect(conn._sentDestroyAuthKey).toBe(false)
+      expect(conn._needDestroyAuthKey).toBe(true)
+      await client.destroy()
+    })
+  })
+
+  it('should remember accepted session identifiers for missed-update recovery', async () => {
+    const { client, conn } = await createConnection()
+    const internals = conn as unknown as SessionConnectionInternals
+    const onUpdate = vi.fn()
+    conn.onUpdate.add(onUpdate)
+    conn.params.disableUpdates = false
+
+    internals._onNewSessionCreated({
+      _: 'mt_new_session_created',
+      firstMsgId: Long.ONE,
+      uniqueId: Long.fromNumber(10),
+      serverSalt: Long.fromNumber(20),
+    })
+    expect(conn._session.lastSessionCreatedUid.eq(Long.fromNumber(10))).toBe(true)
+    expect(onUpdate).not.toHaveBeenCalled()
+
+    internals._onNewSessionCreated({
+      _: 'mt_new_session_created',
+      firstMsgId: Long.fromNumber(2),
+      uniqueId: Long.fromNumber(11),
+      serverSalt: Long.fromNumber(21),
+    })
+    expect(conn._session.lastSessionCreatedUid.eq(Long.fromNumber(11))).toBe(true)
+    expect(onUpdate).toHaveBeenCalledOnce()
+    expect(onUpdate).toHaveBeenCalledWith({ _: 'updatesTooLong' })
+    await client.destroy()
   })
 
   describe('ping handling', () => {

--- a/packages/core/src/network/session-connection.ts
+++ b/packages/core/src/network/session-connection.ts
@@ -43,6 +43,18 @@ export interface SessionConnectionParams extends PersistentConnectionParams {
   platform: ICorePlatform
 }
 
+interface PendingUnencryptedMessage {
+  promise: Deferred<Uint8Array>
+  timeout?: timers.Timer
+  abortSignal?: AbortSignal
+  abortListener?: () => void
+}
+
+interface FlushContext {
+  rpcToSend: PendingRpc[]
+  ownsDestroyAuthKeySend: boolean
+}
+
 const TEMP_AUTH_KEY_EXPIRY = 86400 // 24 hours
 const TEMP_AUTH_KEY_REFRESH_MARGIN = 3600 // refresh 1 hour before expiry
 const TEMP_AUTH_KEY_REFRESH_JITTER = 600 // up to 10 minutes of jitter to desync connections
@@ -76,11 +88,12 @@ export class SessionConnection extends PersistentConnection {
   private _sentDestroyAuthKey = false
 
   // waitForMessage
-  private _pendingWaitForUnencrypted: [Deferred<Uint8Array>, timers.Timer][] = []
+  private _pendingWaitForUnencrypted: PendingUnencryptedMessage[] = []
 
   private _usePfs
   private _isPfsBindingPending = false
   private _isPfsBindingPendingInBackground = false
+  private _pfsAuthorizationAbort?: AbortController
   private _pfsUpdateTimeout?: timers.Timer
 
   private _inactivityPendingFlush = false
@@ -131,6 +144,12 @@ export class SessionConnection extends PersistentConnection {
   private _online
   private _active = false
 
+  private _cancelPfsAuthorization(error: Error): void {
+    this._isPfsBindingPending = false
+    this._isPfsBindingPendingInBackground = false
+    this._pfsAuthorizationAbort?.abort(error)
+  }
+
   getAuthKey(temp = false): Uint8Array | null {
     const key = temp ? this._session._authKeyTemp : this._session._authKey
 
@@ -144,10 +163,9 @@ export class SessionConnection extends PersistentConnection {
 
     this.log.debug('use pfs changed to %s', usePfs)
     this._usePfs = usePfs
+    this._cancelPfsAuthorization(new MtcuteError('PFS setting changed'))
 
     if (!usePfs) {
-      this._isPfsBindingPending = false
-      this._isPfsBindingPendingInBackground = false
       this._session._authKeyTemp.reset()
       timers.clearTimeout(this._pfsUpdateTimeout)
     }
@@ -156,10 +174,7 @@ export class SessionConnection extends PersistentConnection {
   }
 
   onClosed(): void {
-    Object.values(this._pendingWaitForUnencrypted).forEach(([prom, timeout]) => {
-      prom.reject(new MtcuteError('Connection closed'))
-      timers.clearTimeout(timeout)
-    })
+    this._rejectPendingWaitForUnencrypted(new MtcuteError('Connection closed'))
 
     // resend pending state_req-s
     for (const msgId of this._session.pendingGetStateTimeouts.keys()) {
@@ -178,6 +193,7 @@ export class SessionConnection extends PersistentConnection {
   }
 
   override async destroy(): Promise<void> {
+    this._cancelPfsAuthorization(new MtcuteError('Connection destroyed'))
     await super.destroy()
     this.reset(true)
   }
@@ -406,8 +422,13 @@ export class SessionConnection extends PersistentConnection {
       this._isPfsBindingPending = true
     }
 
-    doAuthorization(this, this._crypto, TEMP_AUTH_KEY_EXPIRY)
+    const authorizationAbort = new AbortController()
+    this._pfsAuthorizationAbort = authorizationAbort
+    const { signal } = authorizationAbort
+
+    doAuthorization(this, this._crypto, TEMP_AUTH_KEY_EXPIRY, signal)
       .then(async ([tempAuthKey, tempServerSalt]) => {
+        signal.throwIfAborted()
         if (!this._usePfs) {
           this.log.info('pfs has been disabled while generating temp key')
 
@@ -497,9 +518,12 @@ export class SessionConnection extends PersistentConnection {
           tempServerSalt,
           this._session._sessionId,
         )
+        signal.throwIfAborted()
         await this.send(requestEncrypted)
+        signal.throwIfAborted()
 
         const res = await promise.promise
+        signal.throwIfAborted()
 
         this._session.pendingMessages.delete(msgId)
 
@@ -530,7 +554,9 @@ export class SessionConnection extends PersistentConnection {
         this._session.initConnectionCalled = false
 
         this.onTmpKeyChange.emit([tempAuthKey, inner.expiresAt])
+        signal.throwIfAborted()
         this.onConnectionUsable()
+        signal.throwIfAborted()
 
         // set a timeout to update temp auth key in advance to avoid interruption
         this._pfsUpdateTimeout = timers.setTimeout(
@@ -543,8 +569,9 @@ export class SessionConnection extends PersistentConnection {
         )
       })
       .catch((err: Error) => {
-        if (this._destroyed) return
+        if (this._destroyed || signal.aborted) return
         this.log.error('PFS Authorization error: %e', err)
+        if (this._destroyed || signal.aborted) return
 
         if (this._isPfsBindingPendingInBackground) {
           this._isPfsBindingPendingInBackground = false
@@ -555,20 +582,54 @@ export class SessionConnection extends PersistentConnection {
 
         this._isPfsBindingPending = false
         this.handleError(err)
-        this.reconnect()
+        if (!signal.aborted) this.reconnect()
+      })
+      .finally(() => {
+        if (this._pfsAuthorizationAbort === authorizationAbort) {
+          this._pfsAuthorizationAbort = undefined
+        }
       })
   }
 
-  waitForUnencryptedMessage(timeout = 5000): Promise<Uint8Array> {
+  private _removePendingWaitForUnencrypted(pending: PendingUnencryptedMessage): boolean {
+    const index = this._pendingWaitForUnencrypted.indexOf(pending)
+    if (index === -1) return false
+
+    this._pendingWaitForUnencrypted.splice(index, 1)
+    if (pending.timeout) timers.clearTimeout(pending.timeout)
+    if (pending.abortSignal && pending.abortListener) {
+      pending.abortSignal.removeEventListener('abort', pending.abortListener)
+    }
+
+    return true
+  }
+
+  private _rejectPendingWaitForUnencrypted(error: Error): void {
+    for (const pending of this._pendingWaitForUnencrypted.slice()) {
+      if (this._removePendingWaitForUnencrypted(pending)) pending.promise.reject(error)
+    }
+  }
+
+  waitForUnencryptedMessage(timeout = 5000, abortSignal?: AbortSignal): Promise<Uint8Array> {
     if (this._destroyed) {
       return Promise.reject(new MtcuteError('Connection destroyed'))
     }
+    if (abortSignal?.aborted) return Promise.reject(abortSignal.reason)
+
     const promise = new Deferred<Uint8Array>()
-    const timeoutId = timers.setTimeout(() => {
-      promise.reject(new MtTimeoutError(timeout))
-      this._pendingWaitForUnencrypted = this._pendingWaitForUnencrypted.filter(it => it[0] !== promise)
+    const pending: PendingUnencryptedMessage = { promise, abortSignal }
+    pending.timeout = timers.setTimeout(() => {
+      if (this._removePendingWaitForUnencrypted(pending)) {
+        promise.reject(new MtTimeoutError(timeout))
+      }
     }, timeout)
-    this._pendingWaitForUnencrypted.push([promise, timeoutId])
+    if (abortSignal) {
+      pending.abortListener = () => {
+        if (this._removePendingWaitForUnencrypted(pending)) promise.reject(abortSignal.reason)
+      }
+      abortSignal.addEventListener('abort', pending.abortListener, { once: true })
+    }
+    this._pendingWaitForUnencrypted.push(pending)
 
     return promise.promise
   }
@@ -584,9 +645,8 @@ export class SessionConnection extends PersistentConnection {
       if (int32[0] === 0 && int32[1] === 0) {
         // auth_key_id = 0, meaning it's an unencrypted message used for authorization
 
-        const [promise, timeout] = this._pendingWaitForUnencrypted.shift()!
-        timers.clearTimeout(timeout)
-        promise.resolve(data)
+        const pending = this._pendingWaitForUnencrypted[0]
+        if (this._removePendingWaitForUnencrypted(pending)) pending.promise.resolve(data)
 
         return
       }
@@ -1272,13 +1332,15 @@ export class SessionConnection extends PersistentConnection {
   }
 
   private _onNewSessionCreated({ firstMsgId, serverSalt, uniqueId }: mtp.RawMt_new_session_created): void {
-    if (uniqueId.eq(this._session.lastSessionCreatedUid)) {
+    const previousSessionUid = this._session.lastSessionCreatedUid
+    if (uniqueId.eq(previousSessionUid)) {
       this.log.debug('received new_session_created with the same uid = %l, ignoring', uniqueId)
 
       return
     }
 
-    if (!this._session.lastSessionCreatedUid.isZero() && !this.params.disableUpdates) {
+    this._session.lastSessionCreatedUid = uniqueId
+    if (!previousSessionUid.isZero() && !this.params.disableUpdates) {
       // force the client to fetch missed updates
       // when _lastSessionCreatedUid == 0, the connection has
       // just been established, and the client will fetch them anyways
@@ -1630,8 +1692,10 @@ export class SessionConnection extends PersistentConnection {
     if (!onTimeout && rpc.timeout) {
       timers.clearTimeout(rpc.timeout)
     }
+    rpc.timeout = undefined
 
     rpc.resetAbortSignal?.()
+    rpc.resetAbortSignal = undefined
 
     if (onTimeout) {
       rpc.promise.resolve({
@@ -1779,14 +1843,17 @@ export class SessionConnection extends PersistentConnection {
 
     if (this._checkTimeouts(now)) return
 
-    const rpcToSend: PendingRpc[] = []
+    const flushContext: FlushContext = {
+      rpcToSend: [],
+      ownsDestroyAuthKeySend: false,
+    }
 
     try {
-      this._doFlush(rpcToSend)
-    } catch (e: any) {
+      this._doFlush(flushContext)
+    } catch (cause: unknown) {
       // Selected RPCs have left queuedRpc by this point. Restore any that did not
-      // reach pendingMessages so the session reset can retain them for retry.
-      for (const rpc of rpcToSend) {
+      // reach pendingMessages so terminal reset can settle them.
+      for (const rpc of flushContext.rpcToSend) {
         const pending = rpc.msgId ? this._session.pendingMessages.get(rpc.msgId) : undefined
 
         if (pending?._ === 'rpc' && pending.rpc === rpc) continue
@@ -1797,21 +1864,28 @@ export class SessionConnection extends PersistentConnection {
         this._session.enqueueRpc(rpc, true)
       }
 
-      this.log.error('flush error: %s', (e as Error).stack)
-      // should not happen unless there's a bug in the code. play safe and reset state
-      this._resetSession('flush error')
+      const error = cause instanceof Error
+        ? cause
+        : Object.assign(new Error(typeof cause === 'string' ? cause : 'Non-Error value thrown'), { cause })
+      const resetError = new MtcuteError('Session is reset')
+      const ownsFutureSaltRequest = [...this._session.pendingMessages.values()]
+        .some(info => info._ === 'future_salts')
 
-      // _onAllFailed appends registered RPCs after the ones restored above. Rebuild
-      // the queue so the selected prefix keeps its original order.
-      const selectedRpcs = new Set(rpcToSend)
-      const queuedAfterSelection = this._session.queuedRpc.toArray().filter(rpc => !selectedRpcs.has(rpc))
-      this._session.queuedRpc.clear()
-      for (const rpc of rpcToSend) {
-        if (!rpc.cancelled) this._session.queuedRpc.pushBack(rpc)
-      }
-      for (const rpc of queuedAfterSelection) {
-        this._session.queuedRpc.pushBack(rpc)
-      }
+      // Rejecting PFS waiters runs their promise continuations. Invalidate the
+      // owning attempt before resetState rejects either authorization or bind work.
+      this._cancelPfsAuthorization(resetError)
+
+      this._flushTimer.reset()
+      this._session.initConnectionCalled = false
+      this._active = false
+      this._inactivityPendingFlush = false
+      this._queuedDestroySession.length = 0
+      if (ownsFutureSaltRequest) this._salts.isFetching = false
+      if (flushContext.ownsDestroyAuthKeySend) this._sentDestroyAuthKey = false
+      this._session.resetState()
+
+      this.onError.emit(error)
+      this.log.error('flush error: %e', error)
 
       return
     }
@@ -1837,8 +1911,10 @@ export class SessionConnection extends PersistentConnection {
     }
   }
 
-  private _doFlush(rpcToSend: PendingRpc[]): void {
+  private _doFlush(flushContext: FlushContext): void {
     this.log.debug('flushing send queue. queued rpc: %d', this._session.queuedRpc.length)
+
+    const { rpcToSend } = flushContext
 
     // oh bloody hell mate
 
@@ -1993,7 +2069,6 @@ export class SessionConnection extends PersistentConnection {
       getFutureSaltsRequest = TlBinaryWriter.serializeObject(this._writerMap, obj)
       containerSize += getFutureSaltsRequest.length + 16
       containerMessageCount += 1
-      this._salts.isFetching = true
     }
 
     let forceContainer = false
@@ -2134,7 +2209,6 @@ export class SessionConnection extends PersistentConnection {
 
     if (destroyAuthKey) {
       this._registerOutgoingMsgId(this._session.writeMessage(writer, { _: 'mt_destroy_auth_key' }))
-      this._sentDestroyAuthKey = true
     }
 
     if (getFutureSaltsRequest) {
@@ -2271,10 +2345,19 @@ export class SessionConnection extends PersistentConnection {
     )
 
     const enc = this._session.encryptMessage(result)
+    const sessionId = this._session._sessionId
+    if (destroyAuthKey) {
+      flushContext.ownsDestroyAuthKeySend = true
+      this._sentDestroyAuthKey = true
+    }
+    if (getFutureSaltsRequest) this._salts.isFetching = true
     const promise = this.send(enc)
 
     if (this._inactivityPendingFlush && !this._session.hasPendingMessages) {
       void promise.then(() => {
+        // Only the session that initiated this final write may close the transport.
+        if (!this._inactivityPendingFlush || this._session._sessionId.neq(sessionId)) return
+
         this.log.debug('pending messages sent, closing connection')
         this._flushTimer.reset()
         this._inactivityPendingFlush = false

--- a/packages/core/src/network/session-connection.ts
+++ b/packages/core/src/network/session-connection.ts
@@ -1779,12 +1779,39 @@ export class SessionConnection extends PersistentConnection {
 
     if (this._checkTimeouts(now)) return
 
+    const rpcToSend: PendingRpc[] = []
+
     try {
-      this._doFlush()
+      this._doFlush(rpcToSend)
     } catch (e: any) {
+      // Selected RPCs have left queuedRpc by this point. Restore any that did not
+      // reach pendingMessages so the session reset can retain them for retry.
+      for (const rpc of rpcToSend) {
+        const pending = rpc.msgId ? this._session.pendingMessages.get(rpc.msgId) : undefined
+
+        if (pending?._ === 'rpc' && pending.rpc === rpc) continue
+        if (rpc.cancelled) continue
+
+        rpc.msgId = undefined
+        rpc.seqNo = undefined
+        this._session.enqueueRpc(rpc, true)
+      }
+
       this.log.error('flush error: %s', (e as Error).stack)
       // should not happen unless there's a bug in the code. play safe and reset state
       this._resetSession('flush error')
+
+      // _onAllFailed appends registered RPCs after the ones restored above. Rebuild
+      // the queue so the selected prefix keeps its original order.
+      const selectedRpcs = new Set(rpcToSend)
+      const queuedAfterSelection = this._session.queuedRpc.toArray().filter(rpc => !selectedRpcs.has(rpc))
+      this._session.queuedRpc.clear()
+      for (const rpc of rpcToSend) {
+        if (!rpc.cancelled) this._session.queuedRpc.pushBack(rpc)
+      }
+      for (const rpc of queuedAfterSelection) {
+        this._session.queuedRpc.pushBack(rpc)
+      }
 
       return
     }
@@ -1810,7 +1837,7 @@ export class SessionConnection extends PersistentConnection {
     }
   }
 
-  private _doFlush(): void {
+  private _doFlush(rpcToSend: PendingRpc[]): void {
     this.log.debug('flushing send queue. queued rpc: %d', this._session.queuedRpc.length)
 
     // oh bloody hell mate
@@ -1970,8 +1997,6 @@ export class SessionConnection extends PersistentConnection {
     }
 
     let forceContainer = false
-    const rpcToSend: PendingRpc[] = []
-
     while (
       this._session.queuedRpc.length
       && containerSize < 32768 // 2^15

--- a/packages/core/src/utils/early-timer.test.ts
+++ b/packages/core/src/utils/early-timer.test.ts
@@ -61,6 +61,30 @@ describe('EarlyTimer', () => {
     expect(handler).toHaveBeenCalledOnce()
   })
 
+  it('should cancel an idle emission when reset', async () => {
+    const timer = new EarlyTimer()
+    const handler = vi.fn()
+    timer.onTimeout(handler)
+
+    timer.emitWhenIdle()
+    timer.reset()
+    await Promise.resolve()
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('should supersede an earlier idle emission', async () => {
+    const timer = new EarlyTimer()
+    const handler = vi.fn()
+    timer.onTimeout(handler)
+
+    timer.emitWhenIdle()
+    timer.emitWhenIdle()
+    await Promise.resolve()
+
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
   // https://github.com/mtcute/mtcute/issues/148
   it('should not recurse when re-armed with a past-due deadline and a frozen clock', () => {
     // simulate workerd, where performance.now() is frozen within a task

--- a/packages/core/src/utils/early-timer.ts
+++ b/packages/core/src/utils/early-timer.ts
@@ -7,6 +7,7 @@ import { timers } from '@fuman/utils'
 export class EarlyTimer {
   private _timeout?: timers.Timer
   private _timeoutTs?: number
+  private _generation = 0
 
   private _handler: () => void = () => {}
 
@@ -21,8 +22,11 @@ export class EarlyTimer {
   emitWhenIdle(): void {
     timers.clearTimeout(this._timeout)
     this._timeoutTs = performance.now()
+    const generation = ++this._generation
 
-    queueMicrotask(this.emitNow)
+    queueMicrotask(() => {
+      if (generation === this._generation) this.emitNow()
+    })
   }
 
   /**
@@ -67,6 +71,7 @@ export class EarlyTimer {
   reset(): void {
     timers.clearTimeout(this._timeout)
     this._timeoutTs = undefined
+    this._generation += 1
   }
 
   /**


### PR DESCRIPTION
> **Draft dependency:** This PR is based on #163. After #163 merges, this branch will be rebased onto upstream `master` and the PR will be marked ready for review.

## Problem

When `_doFlush()` throws, the current catch resets the MTProto session while retaining and requeueing its requests. A deterministic packet-construction or encryption error can therefore run the same path repeatedly while callers remain pending.

## Change

Treat the mutated session as failed:

- report the original error through the public `onError` chain;
- reject every queued or registered RPC owned by that session exactly once;
- clear request timers and abort hooks, and cancel the active PFS authorization attempt;
- invalidate queued idle work and stale inactivity continuations;
- preserve the transport, auth keys, time offset, and shared salts;
- do not reconnect or automatically retry failed requests.

A later new request may use a replacement MTProto session on the existing transport. Cleanup completes before `onError` is emitted, so an error listener may submit that new work.

Session-wide rejection is intentional: packet construction mutates shared message IDs, sequence numbers, chains, service queues, pending-message maps, and timers. There is no complete rollback boundary that makes only part of the old session safe to retain.

## Evidence

Nine focused cases were added for exact-once settlement, PFS cancellation and mode changes, stale idle and inactivity work, owner-safe service markers, error delivery, replacement-session bookkeeping, and absence of automatic retry. The three prerequisite ownership cases in #163 also verify settlement under this policy.

Two production CPU profiles were consistent with repeated execution through the flush/reset/requeue path. The original exception was not retained, so this PR does not identify AES-IGE or any other packet operation as the cause.

## Limitations

- Ciphertext already handed to `PersistentConnection.send()` cannot be withdrawn and may still cross the transport boundary.
- Rejected requests have no exactly-once-delivery or remote-cancellation guarantee.
- This does not identify the original packet-construction or encryption error.
- It does not change `PersistentConnection`, transport replacement, or general auth-key and shared-salt lifecycle.
