### PR TITLE
fix(core): account for muteUntil timestamp in Dialog.isMuted

### DIFF
--- a/packages/core/src/highlevel/types/messages/dialog.test.ts
+++ b/packages/core/src/highlevel/types/messages/dialog.test.ts
@@ -1,0 +1,36 @@
+import type { tl } from '../../../tl/index.js'
+
+import { createStub } from '@mtcute/test'
+import { describe, expect, it } from 'vitest'
+
+import { PeersIndex } from '../peers/peers-index.js'
+import { Dialog } from './dialog.js'
+
+function makeDialog(notify: Partial<tl.RawPeerNotifySettings>): Dialog {
+  return new Dialog(
+    createStub('dialog', { notifySettings: createStub('peerNotifySettings', notify) }),
+    new PeersIndex(),
+    new Map(),
+  )
+}
+
+describe('Dialog', () => {
+  describe('isMuted', () => {
+    it('is true when muteUntil is in the future', () => {
+      expect(makeDialog({ muteUntil: Math.floor(Date.now() / 1000) + 1000 }).isMuted).toBe(true)
+    })
+
+    it('is false when muteUntil is in the past', () => {
+      expect(makeDialog({ muteUntil: Math.floor(Date.now() / 1000) - 1000 }).isMuted).toBe(false)
+    })
+
+    it('falls back to the silent flag when muteUntil is unset', () => {
+      expect(makeDialog({ silent: true }).isMuted).toBe(true)
+      expect(makeDialog({ silent: false }).isMuted).toBe(false)
+    })
+
+    it('is null when neither is set', () => {
+      expect(makeDialog({}).isMuted).toBeNull()
+    })
+  })
+})

--- a/packages/core/src/highlevel/types/messages/dialog.ts
+++ b/packages/core/src/highlevel/types/messages/dialog.ts
@@ -179,10 +179,17 @@ export class Dialog {
   /**
    * Whether this dialog is muted.
    *
+   * Accounts for both the `silent` flag and the `muteUntil` timestamp
+   * (a peer muted until a future date is considered muted).
+   *
    * If `null`, the default account-level setting should be used.
    */
   get isMuted(): boolean | null {
-    return this.raw.notifySettings.silent ?? null
+    const { silent, muteUntil } = this.raw.notifySettings
+    if (muteUntil !== undefined) {
+      return muteUntil > Date.now() / 1000
+    }
+    return silent ?? null
   }
 
   /**


### PR DESCRIPTION
## Problem

`Dialog.isMuted` only looked at the `silent` flag on `notifySettings`:

```ts
get isMuted(): boolean | null {
  return this.raw.notifySettings.silent ?? null
}
```

Most of my dialogs currently return `isMuted: null`, even the ones that are actually muted.

## Fix

Check `muteUntil` first and treat a future timestamp as muted, falling back to the `silent` flag (and finally `null`) when it's unset:

```ts
get isMuted(): boolean | null {
  const { silent, muteUntil } = this.raw.notifySettings
  if (muteUntil !== undefined) {
    return muteUntil > Date.now() / 1000
  }
  return silent ?? null
}
```
---

This PR was AI-assisted using Claude Opus 4.8 via Claude Code.
