### PR TITLE
perf(postgres): avoid unnecessary PostgreSQL updates for unchanged peers

### DIFF
--- a/packages/postgres/src/postgres.test.ts
+++ b/packages/postgres/src/postgres.test.ts
@@ -33,6 +33,30 @@ if (process.env.TEST_ENV !== 'web' && process.env.WITH_POSTGRES_TESTS) {
     testPeersRepository(storage.peers, storage.driver)
     testRefMessagesRepository(storage.refMessages, storage.driver)
 
+    it('should skip unchanged peer writes and refresh them every eight hours', async () => {
+      const firstUpdated = 1_700_000_000_000
+      const peer: Parameters<typeof storage.peers.store>[0] = {
+        id: 987654321,
+        accessHash: '123456789',
+        isMin: false,
+        usernames: ['alice'],
+        updated: firstUpdated,
+        complete: new Uint8Array([1, 2, 3]),
+      }
+
+      await storage.peers.store(peer)
+      await storage.peers.store({ ...peer, updated: firstUpdated + 8 * 60 * 60 * 1000 - 1 })
+      expect(await storage.peers.getById(peer.id)).toEqual(peer)
+
+      const refreshed = { ...peer, updated: firstUpdated + 8 * 60 * 60 * 1000 }
+      await storage.peers.store(refreshed)
+      expect(await storage.peers.getById(peer.id)).toEqual(refreshed)
+
+      const changed = { ...refreshed, phone: '+123456789', updated: refreshed.updated + 1 }
+      await storage.peers.store(changed)
+      expect(await storage.peers.getById(peer.id)).toEqual(changed)
+    })
+
     afterAll(async () => {
       await storage.driver.destroy()
       expect(pglite.close).toHaveBeenCalled()

--- a/packages/postgres/src/repository/peers.ts
+++ b/packages/postgres/src/repository/peers.ts
@@ -14,6 +14,8 @@ interface PeerDto {
   complete: import('node:buffer').Buffer
 }
 
+const PEER_REFRESH_INTERVAL_MS = 8 * 60 * 60 * 1000
+
 function mapPeerDto(dto: PeerDto): IPeersRepository.PeerInfo {
   return {
     id: Number(dto.id),
@@ -73,12 +75,25 @@ export class PostgresPeersRepository implements IPeersRepository {
     }
   }
 
+  /**
+   * Creates or updates a peer row. Unchanged peers are refreshed no more than once every 8h because
+   * `getByUsername()` rejects entries older than 24h.
+   *
+   * @see `packages/core/src/highlevel/storage/service/peers.ts` (`PeersService.getByUsername`)
+   */
   async store(peer: IPeersRepository.PeerInfo): Promise<void> {
     await this._driver.client.query(
-      `insert into ${this._table} (account, id, hash, is_min, usernames, updated, phone, complete)
+      `insert into ${this._table} as existing (account, id, hash, is_min, usernames, updated, phone, complete)
        values ($1, $2, $3, $4, $5, $6, $7, $8)
        on conflict (account, id) do update set
-          hash = $3, is_min = $4, usernames = $5, updated = $6, phone = $7, complete = $8`,
+          hash = excluded.hash, is_min = excluded.is_min, usernames = excluded.usernames,
+          updated = excluded.updated, phone = excluded.phone, complete = excluded.complete
+       where existing.hash is distinct from excluded.hash
+          or existing.is_min is distinct from excluded.is_min
+          or existing.usernames is distinct from excluded.usernames
+          or existing.phone is distinct from excluded.phone
+          or existing.complete is distinct from excluded.complete
+          or existing.updated <= excluded.updated - ${PEER_REFRESH_INTERVAL_MS}`,
       [
         this._account,
         peer.id,


### PR DESCRIPTION
## Summary

Stop updating peer rows when nothing changed. Save real changes immediately, and refresh the timestamp no more than once every 8h.

## Impact

After production rollout:

- Tuple updates fell from 1,844/s to 799/s (-56.7%).
- Cluster-wide WAL generation fell from 5.03 MB/s to 3.22 MB/s (-35.9%).

<img width="1086" height="423" alt="image" src="https://github.com/user-attachments/assets/b91d4bfa-dc1e-4708-92b9-711698e192d5" />

## Tests

- All tests pass.
- Verified against PostgreSQL 9.5; the minimum version is unchanged.

## AI disclaimer

AI-assisted with `gpt-5.6-sol` using Codex Desktop.