### PR TITLE
fix(core): re-export auth on SESSION_REVOKED from a non-primary DC

### DIFF
--- a/packages/core/src/network/network-manager.ts
+++ b/packages/core/src/network/network-manager.ts
@@ -969,7 +969,7 @@ export class NetworkManager {
 
         res = await multi.sendRpc(message, params?.timeout, params?.abortSignal, params?.chainId)
       }
-    } else if (err === 'AUTH_KEY_UNREGISTERED') {
+    } else if (err === 'AUTH_KEY_UNREGISTERED' || err === 'SESSION_REVOKED') {
       // we can try re-exporting auth from the primary connection
       this._log.debug('exported auth key error, trying re-exporting..')
 


### PR DESCRIPTION
An authorization exported to a non-primary DC can be invalidated on its own while the primary session stays valid — most reproducibly by calling auth.resetAuthorizations, which terminates exported authorizations along with the other sessions. Telegram reports this as SESSION_REVOKED, not AUTH_KEY_UNREGISTERED, so the existing recovery branch does not catch it and the error surfaces to the caller, where it reads as "the account is logged out".

TDLib treats any auth key loss on a non-main DC as a per-DC event and simply re-runs export/import (DcAuthManager); only losing the main DC's authorization triggers a logout. This aligns mtcute with that behaviour.

The retry stays single-shot and non-primary only. If the account really is logged out, _exportAuthTo fails against the primary DC and the error propagates as before, so a genuine logout is still reported.